### PR TITLE
#47 support | add trace and options request-methods

### DIFF
--- a/src/models/Interaction.model.js
+++ b/src/models/Interaction.model.js
@@ -1,8 +1,17 @@
-const { setMatchingRules, getValue } = require('pactum-matchers').utils;
-const processor = require('../helpers/dataProcessor');
-const helper = require('../helpers/helper');
-const { PactumInteractionError } = require('../helpers/errors');
-const ALLOWED_REQUEST_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD']);
+const { setMatchingRules, getValue } = require("pactum-matchers").utils;
+const processor = require("../helpers/dataProcessor");
+const helper = require("../helpers/helper");
+const { PactumInteractionError } = require("../helpers/errors");
+const ALLOWED_REQUEST_METHODS = new Set([
+  "GET",
+  "POST",
+  "PUT",
+  "DELETE",
+  "PATCH",
+  "HEAD",
+  "OPTIONS",
+  "TRACE",
+]);
 
 function process(raw) {
   processor.processMaps();
@@ -12,19 +21,19 @@ function process(raw) {
 
 function setRawDefaults(raw) {
   if (helper.isValidObject(raw)) {
-    if (typeof raw.strict === 'undefined') {
+    if (typeof raw.strict === "undefined") {
       raw.strict = true;
     }
     if (!raw.response) {
       raw.response = {};
     }
     if (helper.isValidObject(raw.response)) {
-      if (typeof raw.response.status === 'undefined') raw.response.status = 404;
+      if (typeof raw.response.status === "undefined") raw.response.status = 404;
     }
     if (!raw.expects) {
       raw.expects = { exercised: true };
     }
-    if (typeof raw.expects.exercised === 'undefined') {
+    if (typeof raw.expects.exercised === "undefined") {
       raw.expects.exercised = true;
     }
   }
@@ -32,39 +41,41 @@ function setRawDefaults(raw) {
 
 function validate(raw) {
   if (!helper.isValidObject(raw)) {
-    throw new PactumInteractionError('`interaction` is required');
+    throw new PactumInteractionError("`interaction` is required");
   }
   const { request, response } = raw;
   if (!request) {
-    throw new PactumInteractionError('`request` is required');
+    throw new PactumInteractionError("`request` is required");
   }
-  if (typeof request.method !== 'string' || !request.method) {
-    throw new PactumInteractionError('`request.method` is required');
+  if (typeof request.method !== "string" || !request.method) {
+    throw new PactumInteractionError("`request.method` is required");
   }
   if (!ALLOWED_REQUEST_METHODS.has(request.method)) {
-    throw new PactumInteractionError('`request.method` is invalid');
+    throw new PactumInteractionError("`request.method` is invalid");
   }
   if (request.path === undefined || request.path === null) {
-    throw new PactumInteractionError('`request.path` is required');
+    throw new PactumInteractionError("`request.path` is required");
   }
-  if (typeof request.queryParams !== 'undefined') {
+  if (typeof request.queryParams !== "undefined") {
     if (!helper.isValidObject(request.queryParams)) {
-      throw new PactumInteractionError('`request.queryParams` should be object');
+      throw new PactumInteractionError(
+        "`request.queryParams` should be object"
+      );
     }
   }
   if (helper.isValidObject(response)) {
-    if (typeof response.status !== 'number') {
-      throw new PactumInteractionError('`response.status` is required');
+    if (typeof response.status !== "number") {
+      throw new PactumInteractionError("`response.status` is required");
     }
   } else {
-    if (typeof response !== 'function') {
-      throw new PactumInteractionError('`response` is required');
+    if (typeof response !== "function") {
+      throw new PactumInteractionError("`response` is required");
     }
   }
 }
 
 function setResponse(response) {
-  if (typeof response === 'function') {
+  if (typeof response === "function") {
     return response;
   }
   const res = new InteractionResponse(response);
@@ -78,34 +89,31 @@ function setResponse(response) {
 }
 
 class InteractionRequestGraphQL {
-
   constructor(graphQL) {
     this.query = graphQL.query;
     this.variables = graphQL.variables;
   }
-
 }
 
 class InteractionRequest {
-
   constructor(request) {
     this.matchingRules = {};
     this.method = request.method;
     this.path = request.path;
     if (request.pathParams) {
-      setMatchingRules(this.matchingRules, request.pathParams, '$.path');
+      setMatchingRules(this.matchingRules, request.pathParams, "$.path");
       this.pathParams = getValue(request.pathParams);
     }
-    if (request.headers && typeof request.headers === 'object') {
+    if (request.headers && typeof request.headers === "object") {
       const rawLowerCaseHeaders = {};
       for (const prop in request.headers) {
         rawLowerCaseHeaders[prop.toLowerCase()] = request.headers[prop];
       }
-      setMatchingRules(this.matchingRules, rawLowerCaseHeaders, '$.headers');
+      setMatchingRules(this.matchingRules, rawLowerCaseHeaders, "$.headers");
       this.headers = getValue(request.headers);
     }
-    if (request.queryParams && typeof request.queryParams === 'object') {
-      setMatchingRules(this.matchingRules, request.queryParams, '$.query');
+    if (request.queryParams && typeof request.queryParams === "object") {
+      setMatchingRules(this.matchingRules, request.queryParams, "$.query");
       this.queryParams = getValue(request.queryParams);
       for (const prop in this.queryParams) {
         this.queryParams[prop] = this.queryParams[prop].toString();
@@ -113,65 +121,57 @@ class InteractionRequest {
     } else {
       this.queryParams = {};
     }
-    if (request.body && typeof request.body === 'object') {
-      setMatchingRules(this.matchingRules, request.body, '$.body');
+    if (request.body && typeof request.body === "object") {
+      setMatchingRules(this.matchingRules, request.body, "$.body");
       this.body = getValue(request.body);
     }
     if (request.graphQL) {
       this.graphQL = new InteractionRequestGraphQL(request.graphQL);
       this.body = {
         query: request.graphQL.query,
-        variables: request.graphQL.variables
+        variables: request.graphQL.variables,
       };
     }
   }
-
 }
 
 class InteractionResponse {
-
   constructor(response) {
     this.matchingRules = {};
     this.status = response.status;
-    setMatchingRules(this.matchingRules, response.headers, '$.headers');
+    setMatchingRules(this.matchingRules, response.headers, "$.headers");
     this.headers = getValue(response.headers);
-    setMatchingRules(this.matchingRules, response.body, '$.body');
+    setMatchingRules(this.matchingRules, response.body, "$.body");
     this.body = getValue(response.body);
     if (response.fixedDelay) {
-      this.delay = new InteractionResponseDelay('FIXED', response.fixedDelay);
+      this.delay = new InteractionResponseDelay("FIXED", response.fixedDelay);
     } else if (response.randomDelay) {
-      this.delay = new InteractionResponseDelay('RANDOM', response.randomDelay);
+      this.delay = new InteractionResponseDelay("RANDOM", response.randomDelay);
     }
   }
-
 }
 
 class InteractionResponseDelay {
-
   constructor(type, props) {
     this.type = type;
-    if (type === 'RANDOM') {
-      this.subType = 'UNIFORM';
+    if (type === "RANDOM") {
+      this.subType = "UNIFORM";
       this.min = props.min;
       this.max = props.max;
-    } else if (type === 'FIXED') {
+    } else if (type === "FIXED") {
       this.value = props;
     }
   }
-
 }
 
 class InteractionExpectations {
-
   constructor(expects) {
     this.exercised = expects.exercised;
     this.callCount = expects.callCount;
   }
-
 }
 
 class Interaction {
-
   constructor(raw) {
     let unprocessedResponse;
     if (raw && raw.response) {
@@ -187,7 +187,16 @@ class Interaction {
     this.callCount = 0;
     this.exercised = false;
     this.calls = [];
-    const { id, provider, flow, strict, request, response, expects, stores } = raw;
+    const {
+      id,
+      provider,
+      flow,
+      strict,
+      request,
+      response,
+      expects,
+      stores,
+    } = raw;
     this.id = id || helper.getRandomId();
     if (flow) this.flow = flow;
     if (provider) this.provider = provider;
@@ -195,11 +204,10 @@ class Interaction {
     this.request = new InteractionRequest(request);
     this.response = setResponse(response);
     this.expects = new InteractionExpectations(expects);
-    if (stores && typeof stores === 'object') {
+    if (stores && typeof stores === "object") {
       this.stores = stores;
     }
   }
-
 }
 
 module.exports = Interaction;

--- a/src/models/Interaction.model.js
+++ b/src/models/Interaction.model.js
@@ -129,7 +129,7 @@ class InteractionRequest {
       this.graphQL = new InteractionRequestGraphQL(request.graphQL);
       this.body = {
         query: request.graphQL.query,
-        variables: request.graphQL.variables,
+        variables: request.graphQL.variables
       };
     }
   }

--- a/src/models/Interaction.model.js
+++ b/src/models/Interaction.model.js
@@ -1,16 +1,16 @@
-const { setMatchingRules, getValue } = require("pactum-matchers").utils;
-const processor = require("../helpers/dataProcessor");
-const helper = require("../helpers/helper");
-const { PactumInteractionError } = require("../helpers/errors");
+const { setMatchingRules, getValue } = require('pactum-matchers').utils;
+const processor = require('../helpers/dataProcessor');
+const helper = require('../helpers/helper');
+const { PactumInteractionError } = require('../helpers/errors');
 const ALLOWED_REQUEST_METHODS = new Set([
-  "GET",
-  "POST",
-  "PUT",
-  "DELETE",
-  "PATCH",
-  "HEAD",
-  "OPTIONS",
-  "TRACE",
+  'GET',
+  'POST',
+  'PUT',
+  'DELETE',
+  'PATCH',
+  'HEAD',
+  'OPTIONS',
+  'TRACE',
 ]);
 
 function process(raw) {
@@ -21,19 +21,19 @@ function process(raw) {
 
 function setRawDefaults(raw) {
   if (helper.isValidObject(raw)) {
-    if (typeof raw.strict === "undefined") {
+    if (typeof raw.strict === 'undefined') {
       raw.strict = true;
     }
     if (!raw.response) {
       raw.response = {};
     }
     if (helper.isValidObject(raw.response)) {
-      if (typeof raw.response.status === "undefined") raw.response.status = 404;
+      if (typeof raw.response.status === 'undefined') raw.response.status = 404;
     }
     if (!raw.expects) {
       raw.expects = { exercised: true };
     }
-    if (typeof raw.expects.exercised === "undefined") {
+    if (typeof raw.expects.exercised === 'undefined') {
       raw.expects.exercised = true;
     }
   }
@@ -41,41 +41,41 @@ function setRawDefaults(raw) {
 
 function validate(raw) {
   if (!helper.isValidObject(raw)) {
-    throw new PactumInteractionError("`interaction` is required");
+    throw new PactumInteractionError('`interaction` is required');
   }
   const { request, response } = raw;
   if (!request) {
-    throw new PactumInteractionError("`request` is required");
+    throw new PactumInteractionError('`request` is required');
   }
-  if (typeof request.method !== "string" || !request.method) {
-    throw new PactumInteractionError("`request.method` is required");
+  if (typeof request.method !== 'string' || !request.method) {
+    throw new PactumInteractionError('`request.method` is required');
   }
   if (!ALLOWED_REQUEST_METHODS.has(request.method)) {
-    throw new PactumInteractionError("`request.method` is invalid");
+    throw new PactumInteractionError('`request.method` is invalid');
   }
   if (request.path === undefined || request.path === null) {
-    throw new PactumInteractionError("`request.path` is required");
+    throw new PactumInteractionError('`request.path` is required');
   }
-  if (typeof request.queryParams !== "undefined") {
+  if (typeof request.queryParams !== 'undefined') {
     if (!helper.isValidObject(request.queryParams)) {
       throw new PactumInteractionError(
-        "`request.queryParams` should be object"
+        '`request.queryParams` should be object'
       );
     }
   }
   if (helper.isValidObject(response)) {
-    if (typeof response.status !== "number") {
-      throw new PactumInteractionError("`response.status` is required");
+    if (typeof response.status !== 'number') {
+      throw new PactumInteractionError('`response.status` is required');
     }
   } else {
-    if (typeof response !== "function") {
-      throw new PactumInteractionError("`response` is required");
+    if (typeof response !== 'function') {
+      throw new PactumInteractionError('`response` is required');
     }
   }
 }
 
 function setResponse(response) {
-  if (typeof response === "function") {
+  if (typeof response === 'function') {
     return response;
   }
   const res = new InteractionResponse(response);
@@ -101,19 +101,19 @@ class InteractionRequest {
     this.method = request.method;
     this.path = request.path;
     if (request.pathParams) {
-      setMatchingRules(this.matchingRules, request.pathParams, "$.path");
+      setMatchingRules(this.matchingRules, request.pathParams, '$.path');
       this.pathParams = getValue(request.pathParams);
     }
-    if (request.headers && typeof request.headers === "object") {
+    if (request.headers && typeof request.headers === 'object') {
       const rawLowerCaseHeaders = {};
       for (const prop in request.headers) {
         rawLowerCaseHeaders[prop.toLowerCase()] = request.headers[prop];
       }
-      setMatchingRules(this.matchingRules, rawLowerCaseHeaders, "$.headers");
+      setMatchingRules(this.matchingRules, rawLowerCaseHeaders, '$.headers');
       this.headers = getValue(request.headers);
     }
-    if (request.queryParams && typeof request.queryParams === "object") {
-      setMatchingRules(this.matchingRules, request.queryParams, "$.query");
+    if (request.queryParams && typeof request.queryParams === 'object') {
+      setMatchingRules(this.matchingRules, request.queryParams, '$.query');
       this.queryParams = getValue(request.queryParams);
       for (const prop in this.queryParams) {
         this.queryParams[prop] = this.queryParams[prop].toString();
@@ -121,8 +121,8 @@ class InteractionRequest {
     } else {
       this.queryParams = {};
     }
-    if (request.body && typeof request.body === "object") {
-      setMatchingRules(this.matchingRules, request.body, "$.body");
+    if (request.body && typeof request.body === 'object') {
+      setMatchingRules(this.matchingRules, request.body, '$.body');
       this.body = getValue(request.body);
     }
     if (request.graphQL) {
@@ -139,14 +139,14 @@ class InteractionResponse {
   constructor(response) {
     this.matchingRules = {};
     this.status = response.status;
-    setMatchingRules(this.matchingRules, response.headers, "$.headers");
+    setMatchingRules(this.matchingRules, response.headers, '$.headers');
     this.headers = getValue(response.headers);
-    setMatchingRules(this.matchingRules, response.body, "$.body");
+    setMatchingRules(this.matchingRules, response.body, '$.body');
     this.body = getValue(response.body);
     if (response.fixedDelay) {
-      this.delay = new InteractionResponseDelay("FIXED", response.fixedDelay);
+      this.delay = new InteractionResponseDelay('FIXED', response.fixedDelay);
     } else if (response.randomDelay) {
-      this.delay = new InteractionResponseDelay("RANDOM", response.randomDelay);
+      this.delay = new InteractionResponseDelay('RANDOM', response.randomDelay);
     }
   }
 }
@@ -154,11 +154,11 @@ class InteractionResponse {
 class InteractionResponseDelay {
   constructor(type, props) {
     this.type = type;
-    if (type === "RANDOM") {
-      this.subType = "UNIFORM";
+    if (type === 'RANDOM') {
+      this.subType = 'UNIFORM';
       this.min = props.min;
       this.max = props.max;
-    } else if (type === "FIXED") {
+    } else if (type === 'FIXED') {
       this.value = props;
     }
   }
@@ -204,7 +204,7 @@ class Interaction {
     this.request = new InteractionRequest(request);
     this.response = setResponse(response);
     this.expects = new InteractionExpectations(expects);
-    if (stores && typeof stores === "object") {
+    if (stores && typeof stores === 'object') {
       this.stores = stores;
     }
   }

--- a/src/models/Spec.d.ts
+++ b/src/models/Spec.d.ts
@@ -140,6 +140,39 @@ declare class Spec {
   delete(url: string): Spec;
 
   /**
+   * The OPTIONS method asks for request-methods supported by the request.
+   * @example
+   * await pactum.spec()
+   *  .options('https://jsonplaceholder.typicode.com/posts')
+   *  .expectStatus(204)
+   *  .expectHeader('Access-Control-Allow-Methods', 'GET,HEAD,PUT,PATCH,POST,DELETE');
+   */
+   options(url: string): Spec;
+  
+   /**
+    * The TRACE method echos the contents of an HTTP Request back to the requester
+    * @example
+    * await pactum.spec()
+    *  .trace('http://localhost:9393/projects/1')
+    *  .expectStatus(200);
+    */
+   trace(url: string): Spec;
+ 
+   /**
+    * The WITHMETHOD method extends the support for the request-methods apart from 
+    * (GET, POST, DELETE, PATCH, PUT, HEAD)
+    * 
+    * The WITHPATH method triggers the request passed through withMethod()
+    * @example
+    * await pactum.spec()
+    *  .withMethod('HEAD')
+    *  .withPath('https://jsonplaceholder.typicode.com/posts')
+    *  .expectStatus(200);
+    */
+   withMethod(method: string): Spec;
+   withPath(url: string): Spec;
+   
+  /**
    * replaces path params in the request url - /api/users/mike
    * @example
    * await pactum.spec()

--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -13,7 +13,6 @@ const hr = require('../helpers/handler.runner');
 const rlc = require('../helpers/reporter.lifeCycle');
 
 class Spec {
-
   constructor(name, data) {
     this.id = helper.getRandomId();
     this.flow = '';
@@ -100,14 +99,14 @@ class Spec {
   options(url) {
     validateRequestUrl(this._request, url);
     this._request.url = url;
-    this._request.method = "OPTIONS";
+    this._request.method = 'OPTIONS';
     return this;
   }
 
   trace(url) {
     validateRequestUrl(this._request, url);
     this._request.url = url;
-    this._request.method = "TRACE";
+    this._request.method = 'TRACE';
     return this;
   }
 
@@ -202,7 +201,9 @@ class Spec {
 
   withBody(body) {
     if (typeof this._request.data !== 'undefined') {
-      throw new PactumRequestError(`Duplicate body in request - ${this._request.data}`);
+      throw new PactumRequestError(
+        `Duplicate body in request - ${this._request.data}`
+      );
     }
     this._request.data = body;
     return this;
@@ -244,7 +245,9 @@ class Spec {
     if (!options) {
       options = {};
     }
-    options.filename = options.filename ? options.filename : path.basename(filePath);
+    options.filename = options.filename
+      ? options.filename
+      : path.basename(filePath);
     return this.withMultiPartFormData(key, fs.readFileSync(filePath), options);
   }
 
@@ -310,7 +313,7 @@ class Spec {
   expectHeader(header, value) {
     this._expect.headers.push({
       key: header,
-      value
+      value,
     });
     return this;
   }
@@ -318,7 +321,7 @@ class Spec {
   expectHeaderContains(header, value) {
     this._expect.headerContains.push({
       key: header,
-      value
+      value,
     });
     return this;
   }
@@ -442,13 +445,15 @@ class Spec {
 
   then(resolve, reject) {
     this.toss()
-      .then(res => resolve(res))
-      .catch(err => reject(err));
+      .then((res) => resolve(res))
+      .catch((err) => reject(err));
   }
 
   response() {
     if (!this._response) {
-      throw new PactumRequestError(`'response()' should be called after resolving 'toss()'`);
+      throw new PactumRequestError(
+        `'response()' should be called after resolving 'toss()'`
+      );
     }
     return responseExpect(this._response, this);
   }
@@ -457,12 +462,13 @@ class Spec {
     rlc.afterSpecReport(this);
     return this;
   }
-
 }
 
 function validateRequestUrl(request, url) {
   if (request.url && request.method) {
-    throw new PactumRequestError(`Duplicate request initiated. Existing request - ${request.method} ${request.url}`);
+    throw new PactumRequestError(
+      `Duplicate request initiated. Existing request - ${request.method} ${request.url}`
+    );
   }
   if (!helper.isValidString(url)) {
     throw new PactumRequestError(`Invalid request url - ${url}`);

--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -313,7 +313,7 @@ class Spec {
   expectHeader(header, value) {
     this._expect.headers.push({
       key: header,
-      value,
+      value
     });
     return this;
   }
@@ -321,7 +321,7 @@ class Spec {
   expectHeaderContains(header, value) {
     this._expect.headerContains.push({
       key: header,
-      value,
+      value
     });
     return this;
   }
@@ -445,8 +445,8 @@ class Spec {
 
   then(resolve, reject) {
     this.toss()
-      .then((res) => resolve(res))
-      .catch((err) => reject(err));
+      .then(res => resolve(res))
+      .catch(err => reject(err));
   }
 
   response() {

--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -97,6 +97,31 @@ class Spec {
     return this;
   }
 
+  options(url) {
+    validateRequestUrl(this._request, url);
+    this._request.url = url;
+    this._request.method = "OPTIONS";
+    return this;
+  }
+
+  trace(url) {
+    validateRequestUrl(this._request, url);
+    this._request.url = url;
+    this._request.method = "TRACE";
+    return this;
+  }
+
+  withMethod(method) {
+    this._request.method = method;
+    return this;
+  }
+
+  withPath(url) {
+    validateRequestUrl(this._request, url);
+    this._request.url = url;
+    return this;
+  }
+
   withPathParams(key, value) {
     if (!this._request.pathParams) {
       this._request.pathParams = {};

--- a/test/component/request.spec.js
+++ b/test/component/request.spec.js
@@ -1,241 +1,241 @@
-const pactum = require("../../src/index");
+const pactum = require('../../src/index');
 const request = pactum.request;
-const config = require("../../src/config");
+const config = require('../../src/config');
 
-describe("Request", () => {
-  it("GET with baseurl", async () => {
-    request.setBaseUrl("http://localhost:9393");
+describe('Request', () => {
+  it('GET with baseurl', async () => {
+    request.setBaseUrl('http://localhost:9393');
     await pactum
       .spec()
       .useInteraction({
         request: {
-          method: "GET",
-          path: "/users",
+          method: 'GET',
+          path: '/users',
         },
         response: {
           status: 200,
         },
       })
-      .get("/users")
+      .get('/users')
       .expectStatus(200)
       .inspect();
   });
 
-  it("OPTIONS with baseurl", async () => {
-    request.setBaseUrl("http://localhost:9393");
+  it('OPTIONS with baseurl', async () => {
+    request.setBaseUrl('http://localhost:9393');
     await pactum
       .spec()
       .useInteraction({
         request: {
-          method: "OPTIONS",
-          path: "/users",
+          method: 'OPTIONS',
+          path: '/users',
         },
         response: {
           status: 204,
           headers: {
-            "access-control-allow-methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
+            'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
           },
         },
       })
-      .options("/users")
+      .options('/users')
       .expectStatus(204)
       .expectHeader(
-        "access-control-allow-methods",
-        "GET,HEAD,PUT,PATCH,POST,DELETE"
+        'access-control-allow-methods',
+        'GET,HEAD,PUT,PATCH,POST,DELETE'
       );
   });
 
-  it("TRACE with baseurl", async () => {
-    request.setBaseUrl("http://localhost:9393");
+  it('TRACE with baseurl', async () => {
+    request.setBaseUrl('http://localhost:9393');
     await pactum
       .spec()
       .useInteraction({
         request: {
-          method: "TRACE",
-          path: "/users",
+          method: 'TRACE',
+          path: '/users',
         },
         response: {
           status: 200,
         },
       })
-      .trace("/users")
+      .trace('/users')
       .expectStatus(200);
   });
 
-  it("HEAD with baseurl", async () => {
-    request.setBaseUrl("http://localhost:9393");
+  it('HEAD with baseurl', async () => {
+    request.setBaseUrl('http://localhost:9393');
     await pactum
       .spec()
       .useInteraction({
         request: {
-          method: "HEAD",
-          path: "/users",
+          method: 'HEAD',
+          path: '/users',
         },
         response: {
           status: 200,
         },
       })
-      .withMethod("HEAD")
-      .withPath("/users")
+      .withMethod('HEAD')
+      .withPath('/users')
       .expectStatus(200);
   });
 
-  it("with baseurl override", async () => {
-    request.setBaseUrl("http://localhost:9392");
+  it('with baseurl override', async () => {
+    request.setBaseUrl('http://localhost:9392');
     await pactum
       .spec()
       .useInteraction({
         request: {
-          method: "GET",
-          path: "/users",
+          method: 'GET',
+          path: '/users',
         },
         response: {
           status: 200,
         },
       })
-      .get("http://localhost:9393/users")
+      .get('http://localhost:9393/users')
       .expectStatus(200);
   });
 
-  it("with default header", async () => {
-    request.setBaseUrl("http://localhost:9393");
-    request.setDefaultHeaders("x", "a");
+  it('with default header', async () => {
+    request.setBaseUrl('http://localhost:9393');
+    request.setDefaultHeaders('x', 'a');
     await pactum
       .spec()
       .useInteraction({
         request: {
-          method: "GET",
-          path: "/users",
+          method: 'GET',
+          path: '/users',
           headers: {
-            x: "a",
+            x: 'a',
           },
         },
         response: {
           status: 200,
         },
       })
-      .get("http://localhost:9393/users")
+      .get('http://localhost:9393/users')
       .expectStatus(200);
   });
 
-  it("with override default header to empty value", async () => {
-    request.setBaseUrl("http://localhost:9393");
-    request.setDefaultHeaders("x", "a");
+  it('with override default header to empty value', async () => {
+    request.setBaseUrl('http://localhost:9393');
+    request.setDefaultHeaders('x', 'a');
     await pactum
       .spec()
       .useInteraction({
         request: {
-          method: "GET",
-          path: "/users",
+          method: 'GET',
+          path: '/users',
           headers: {
-            x: "",
+            x: '',
           },
         },
         response: {
           status: 200,
         },
       })
-      .get("http://localhost:9393/users")
-      .withHeaders("x", "")
+      .get('http://localhost:9393/users')
+      .withHeaders('x', '')
       .expectStatus(200);
   });
 
-  it("with override default header", async () => {
-    request.setBaseUrl("http://localhost:9393");
-    request.setDefaultHeaders("x", "a");
+  it('with override default header', async () => {
+    request.setBaseUrl('http://localhost:9393');
+    request.setDefaultHeaders('x', 'a');
     await pactum
       .spec()
       .useInteraction({
         request: {
-          method: "GET",
-          path: "/users",
+          method: 'GET',
+          path: '/users',
           headers: {
-            x: "b",
+            x: 'b',
           },
         },
         response: {
           status: 200,
         },
       })
-      .get("http://localhost:9393/users")
-      .withHeaders("x", "b")
+      .get('http://localhost:9393/users')
+      .withHeaders('x', 'b')
       .expectStatus(200);
   });
 
-  it("with file - just path", async () => {
+  it('with file - just path', async () => {
     await pactum
       .spec()
       .useInteraction({
         strict: false,
         request: {
-          method: "POST",
-          path: "/api/file",
+          method: 'POST',
+          path: '/api/file',
         },
         response: {
           status: 200,
         },
       })
-      .post("http://localhost:9393/api/file")
-      .withFile("./package.json")
+      .post('http://localhost:9393/api/file')
+      .withFile('./package.json')
       .expectStatus(200);
   });
 
-  it("with file - path & options", async () => {
+  it('with file - path & options', async () => {
     await pactum
       .spec()
       .useInteraction({
         strict: false,
         request: {
-          method: "POST",
-          path: "/api/file",
+          method: 'POST',
+          path: '/api/file',
         },
         response: {
           status: 200,
         },
       })
-      .post("http://localhost:9393/api/file")
-      .withFile("./package.json", { contentType: "application/json" })
+      .post('http://localhost:9393/api/file')
+      .withFile('./package.json', { contentType: 'application/json' })
       .expectStatus(200);
   });
 
-  it("with file - key & path", async () => {
+  it('with file - key & path', async () => {
     await pactum
       .spec()
       .useInteraction({
         strict: false,
         request: {
-          method: "POST",
-          path: "/api/file",
+          method: 'POST',
+          path: '/api/file',
         },
         response: {
           status: 200,
         },
       })
-      .post("http://localhost:9393/api/file")
-      .withFile("file-2", "./package.json")
+      .post('http://localhost:9393/api/file')
+      .withFile('file-2', './package.json')
       .expectStatus(200);
   });
 
-  it("with file - key, path & options", async () => {
+  it('with file - key, path & options', async () => {
     await pactum
       .spec()
       .useInteraction({
         strict: false,
         request: {
-          method: "POST",
-          path: "/api/file",
+          method: 'POST',
+          path: '/api/file',
         },
         response: {
           status: 200,
         },
       })
-      .post("http://localhost:9393/api/file")
-      .withFile("file-2", "./package.json", { contentType: "application/json" })
+      .post('http://localhost:9393/api/file')
+      .withFile('file-2', './package.json', { contentType: 'application/json' })
       .expectStatus(200);
   });
 
   afterEach(() => {
-    config.request.baseUrl = "";
+    config.request.baseUrl = '';
     config.request.headers = {};
   });
 });

--- a/test/component/request.spec.js
+++ b/test/component/request.spec.js
@@ -10,11 +10,11 @@ describe('Request', () => {
       .useInteraction({
         request: {
           method: 'GET',
-          path: '/users',
+          path: '/users'
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .get('/users')
       .expectStatus(200)
@@ -28,14 +28,14 @@ describe('Request', () => {
       .useInteraction({
         request: {
           method: 'OPTIONS',
-          path: '/users',
+          path: '/users'
         },
         response: {
           status: 204,
           headers: {
-            'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
-          },
-        },
+            'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE'
+          }
+        }
       })
       .options('/users')
       .expectStatus(204)
@@ -52,11 +52,11 @@ describe('Request', () => {
       .useInteraction({
         request: {
           method: 'TRACE',
-          path: '/users',
+          path: '/users'
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .trace('/users')
       .expectStatus(200);
@@ -69,11 +69,11 @@ describe('Request', () => {
       .useInteraction({
         request: {
           method: 'HEAD',
-          path: '/users',
+          path: '/users'
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .withMethod('HEAD')
       .withPath('/users')
@@ -87,11 +87,11 @@ describe('Request', () => {
       .useInteraction({
         request: {
           method: 'GET',
-          path: '/users',
+          path: '/users'
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .get('http://localhost:9393/users')
       .expectStatus(200);
@@ -107,12 +107,12 @@ describe('Request', () => {
           method: 'GET',
           path: '/users',
           headers: {
-            x: 'a',
-          },
+            'x': 'a'
+          }
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .get('http://localhost:9393/users')
       .expectStatus(200);
@@ -128,12 +128,12 @@ describe('Request', () => {
           method: 'GET',
           path: '/users',
           headers: {
-            x: '',
-          },
+            'x': ''
+          }
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .get('http://localhost:9393/users')
       .withHeaders('x', '')
@@ -150,12 +150,12 @@ describe('Request', () => {
           method: 'GET',
           path: '/users',
           headers: {
-            x: 'b',
-          },
+            'x': 'b'
+          }
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .get('http://localhost:9393/users')
       .withHeaders('x', 'b')
@@ -169,11 +169,11 @@ describe('Request', () => {
         strict: false,
         request: {
           method: 'POST',
-          path: '/api/file',
+          path: '/api/file'
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .post('http://localhost:9393/api/file')
       .withFile('./package.json')
@@ -187,11 +187,11 @@ describe('Request', () => {
         strict: false,
         request: {
           method: 'POST',
-          path: '/api/file',
+          path: '/api/file'
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .post('http://localhost:9393/api/file')
       .withFile('./package.json', { contentType: 'application/json' })
@@ -205,11 +205,11 @@ describe('Request', () => {
         strict: false,
         request: {
           method: 'POST',
-          path: '/api/file',
+          path: '/api/file'
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .post('http://localhost:9393/api/file')
       .withFile('file-2', './package.json')
@@ -223,11 +223,11 @@ describe('Request', () => {
         strict: false,
         request: {
           method: 'POST',
-          path: '/api/file',
+          path: '/api/file'
         },
         response: {
-          status: 200,
-        },
+          status: 200
+        }
       })
       .post('http://localhost:9393/api/file')
       .withFile('file-2', './package.json', { contentType: 'application/json' })

--- a/test/component/request.spec.js
+++ b/test/component/request.spec.js
@@ -62,6 +62,24 @@ describe("Request", () => {
       .expectStatus(200);
   });
 
+  it("HEAD with baseurl", async () => {
+    request.setBaseUrl("http://localhost:9393");
+    await pactum
+      .spec()
+      .useInteraction({
+        request: {
+          method: "HEAD",
+          path: "/users",
+        },
+        response: {
+          status: 200,
+        },
+      })
+      .withMethod("HEAD")
+      .withPath("/users")
+      .expectStatus(200);
+  });
+
   it("with baseurl override", async () => {
     request.setBaseUrl("http://localhost:9392");
     await pactum

--- a/test/component/request.spec.js
+++ b/test/component/request.spec.js
@@ -1,175 +1,223 @@
-const pactum = require('../../src/index');
+const pactum = require("../../src/index");
 const request = pactum.request;
-const config = require('../../src/config');
+const config = require("../../src/config");
 
-describe('Request', () => {
-
-  it('with baseurl', async () => {
-    request.setBaseUrl('http://localhost:9393');
-    await pactum.spec()
+describe("Request", () => {
+  it("GET with baseurl", async () => {
+    request.setBaseUrl("http://localhost:9393");
+    await pactum
+      .spec()
       .useInteraction({
         request: {
-          method: 'GET',
-          path: '/users'
+          method: "GET",
+          path: "/users",
         },
         response: {
-          status: 200
-        }
+          status: 200,
+        },
       })
-      .get('/users')
+      .get("/users")
       .expectStatus(200)
       .inspect();
   });
 
-  it('with baseurl override', async () => {
-    request.setBaseUrl('http://localhost:9392');
-    await pactum.spec()
+  it("OPTIONS with baseurl", async () => {
+    request.setBaseUrl("http://localhost:9393");
+    await pactum
+      .spec()
       .useInteraction({
         request: {
-          method: 'GET',
-          path: '/users'
+          method: "OPTIONS",
+          path: "/users",
         },
         response: {
-          status: 200
-        }
-      })
-      .get('http://localhost:9393/users')
-      .expectStatus(200);
-  });
-
-  it('with default header', async () => {
-    request.setBaseUrl('http://localhost:9393');
-    request.setDefaultHeaders('x', 'a');
-    await pactum.spec()
-      .useInteraction({
-        request: {
-          method: 'GET',
-          path: '/users',
+          status: 204,
           headers: {
-            'x': 'a'
-          }
+            "access-control-allow-methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
+          },
+        },
+      })
+      .options("/users")
+      .expectStatus(204)
+      .expectHeader(
+        "access-control-allow-methods",
+        "GET,HEAD,PUT,PATCH,POST,DELETE"
+      );
+  });
+
+  it("TRACE with baseurl", async () => {
+    request.setBaseUrl("http://localhost:9393");
+    await pactum
+      .spec()
+      .useInteraction({
+        request: {
+          method: "TRACE",
+          path: "/users",
         },
         response: {
-          status: 200
-        }
+          status: 200,
+        },
       })
-      .get('http://localhost:9393/users')
+      .trace("/users")
       .expectStatus(200);
   });
 
-  it('with override default header to empty value', async () => {
-    request.setBaseUrl('http://localhost:9393');
-    request.setDefaultHeaders('x', 'a');
-    await pactum.spec()
+  it("with baseurl override", async () => {
+    request.setBaseUrl("http://localhost:9392");
+    await pactum
+      .spec()
       .useInteraction({
         request: {
-          method: 'GET',
-          path: '/users',
+          method: "GET",
+          path: "/users",
+        },
+        response: {
+          status: 200,
+        },
+      })
+      .get("http://localhost:9393/users")
+      .expectStatus(200);
+  });
+
+  it("with default header", async () => {
+    request.setBaseUrl("http://localhost:9393");
+    request.setDefaultHeaders("x", "a");
+    await pactum
+      .spec()
+      .useInteraction({
+        request: {
+          method: "GET",
+          path: "/users",
           headers: {
-            'x': ''
-          }
+            x: "a",
+          },
         },
         response: {
-          status: 200
-        }
+          status: 200,
+        },
       })
-      .get('http://localhost:9393/users')
-      .withHeaders('x', '')
+      .get("http://localhost:9393/users")
       .expectStatus(200);
   });
 
-  it('with override default header', async () => {
-    request.setBaseUrl('http://localhost:9393');
-    request.setDefaultHeaders('x', 'a');
-    await pactum.spec()
+  it("with override default header to empty value", async () => {
+    request.setBaseUrl("http://localhost:9393");
+    request.setDefaultHeaders("x", "a");
+    await pactum
+      .spec()
       .useInteraction({
         request: {
-          method: 'GET',
-          path: '/users',
+          method: "GET",
+          path: "/users",
           headers: {
-            'x': 'b'
-          }
+            x: "",
+          },
         },
         response: {
-          status: 200
-        }
+          status: 200,
+        },
       })
-      .get('http://localhost:9393/users')
-      .withHeaders('x', 'b')
+      .get("http://localhost:9393/users")
+      .withHeaders("x", "")
       .expectStatus(200);
   });
 
-  it('with file - just path', async () => {
-    await pactum.spec()
+  it("with override default header", async () => {
+    request.setBaseUrl("http://localhost:9393");
+    request.setDefaultHeaders("x", "a");
+    await pactum
+      .spec()
       .useInteraction({
-        strict: false,
         request: {
-          method: 'POST',
-          path: '/api/file'
+          method: "GET",
+          path: "/users",
+          headers: {
+            x: "b",
+          },
         },
         response: {
-          status: 200
-        }
+          status: 200,
+        },
       })
-      .post('http://localhost:9393/api/file')
-      .withFile('./package.json')
+      .get("http://localhost:9393/users")
+      .withHeaders("x", "b")
       .expectStatus(200);
   });
 
-  it('with file - path & options', async () => {
-    await pactum.spec()
+  it("with file - just path", async () => {
+    await pactum
+      .spec()
       .useInteraction({
         strict: false,
         request: {
-          method: 'POST',
-          path: '/api/file'
+          method: "POST",
+          path: "/api/file",
         },
         response: {
-          status: 200
-        }
+          status: 200,
+        },
       })
-      .post('http://localhost:9393/api/file')
-      .withFile('./package.json', { contentType: 'application/json' })
+      .post("http://localhost:9393/api/file")
+      .withFile("./package.json")
       .expectStatus(200);
   });
 
-  it('with file - key & path', async () => {
-    await pactum.spec()
+  it("with file - path & options", async () => {
+    await pactum
+      .spec()
       .useInteraction({
         strict: false,
         request: {
-          method: 'POST',
-          path: '/api/file'
+          method: "POST",
+          path: "/api/file",
         },
         response: {
-          status: 200
-        }
+          status: 200,
+        },
       })
-      .post('http://localhost:9393/api/file')
-      .withFile('file-2', './package.json')
+      .post("http://localhost:9393/api/file")
+      .withFile("./package.json", { contentType: "application/json" })
       .expectStatus(200);
   });
 
-  it('with file - key, path & options', async () => {
-    await pactum.spec()
+  it("with file - key & path", async () => {
+    await pactum
+      .spec()
       .useInteraction({
         strict: false,
         request: {
-          method: 'POST',
-          path: '/api/file'
+          method: "POST",
+          path: "/api/file",
         },
         response: {
-          status: 200
-        }
+          status: 200,
+        },
       })
-      .post('http://localhost:9393/api/file')
-      .withFile('file-2', './package.json', { contentType: 'application/json' })
+      .post("http://localhost:9393/api/file")
+      .withFile("file-2", "./package.json")
+      .expectStatus(200);
+  });
+
+  it("with file - key, path & options", async () => {
+    await pactum
+      .spec()
+      .useInteraction({
+        strict: false,
+        request: {
+          method: "POST",
+          path: "/api/file",
+        },
+        response: {
+          status: 200,
+        },
+      })
+      .post("http://localhost:9393/api/file")
+      .withFile("file-2", "./package.json", { contentType: "application/json" })
       .expectStatus(200);
   });
 
   afterEach(() => {
-    config.request.baseUrl = '';
+    config.request.baseUrl = "";
     config.request.headers = {};
   });
-
 });


### PR DESCRIPTION
Support for OPTIONS and TRACE request-methods added.
Also, withPath and withMethod methods have been added.

(a) Files Updated :
- models/spec.js
- models/spec.d.ts

(b) Methods implemented in spec.js:
- options(url)
- trace(url)
- withPath(url)
- withMethod(method)

(c) Tests added in request.spec.js

(d) Interaction.model.js 
- "OPTIONS" and "TRACE" added in ALLOWED_REQUEST_METHODS 
  
