### PR TITLE
Supoprt skip interaction exercised in exceptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pactum",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1655,9 +1655,9 @@
       }
     },
     "pactum-matchers": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/pactum-matchers/-/pactum-matchers-1.0.5.tgz",
-      "integrity": "sha512-WANTu9+JDIo079pCAXQGsLWepdUtj0bXU+uzPSbeE/H9a6TYfi4793Gkt4QY3+t46c5n5KdDnCCYtGugrYZlcg=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pactum-matchers/-/pactum-matchers-1.0.6.tgz",
+      "integrity": "sha512-vUXnIAEmQdg3tKXzcj2OFhB1A492u+c89ps6JY6aDH0xH29fbyDYmnHl4xtp3peQosq8AOqC9D6eTXMAhcE5xw=="
     },
     "parse-graphql": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pactum",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "REST API Testing Tool for all levels in a Test Pyramid",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
@@ -67,7 +67,7 @@
     "klona": "^2.0.4",
     "lightcookie": "^1.0.25",
     "openapi-fuzzer-core": "^1.0.6",
-    "pactum-matchers": "^1.0.5",
+    "pactum-matchers": "^1.0.6",
     "parse-graphql": "^1.0.0",
     "phin": "^3.6.0",
     "polka": "^0.5.2"

--- a/src/exports/mock.d.ts
+++ b/src/exports/mock.d.ts
@@ -41,6 +41,10 @@ export interface InteractionExpectations {
   callCount?: number;
 }
 
+export interface InteractionExceptions {
+  checkExercised?: boolean;
+}
+
 // TODO - accept function - (req, res)
 export interface Interaction {
   id?: string;
@@ -53,6 +57,7 @@ export interface Interaction {
   request: InteractionRequest;
   response: InteractionResponse;
   expects?: InteractionExpectations;
+  exceptions?: InteractionExceptions;
 }
 
 export interface InteractionDetails {

--- a/src/exports/mock.d.ts
+++ b/src/exports/mock.d.ts
@@ -37,12 +37,9 @@ export interface InteractionResponse {
 }
 
 export interface InteractionExpectations {
+  disable?: boolean;
   exercised?: boolean;
   callCount?: number;
-}
-
-export interface InteractionExceptions {
-  checkExercised?: boolean;
 }
 
 // TODO - accept function - (req, res)
@@ -57,7 +54,6 @@ export interface Interaction {
   request: InteractionRequest;
   response: InteractionResponse;
   expects?: InteractionExpectations;
-  exceptions?: InteractionExceptions;
 }
 
 export interface InteractionDetails {

--- a/src/models/Interaction.model.js
+++ b/src/models/Interaction.model.js
@@ -24,6 +24,12 @@ function setRawDefaults(raw) {
     if (typeof raw.strict === 'undefined') {
       raw.strict = true;
     }
+    if (!raw.exceptions) {
+      raw.exceptions = { checkExercised: true };
+    }
+    if (typeof raw.exceptions.checkExercised === 'undefined') {
+      raw.exceptions.checkExercised = true;
+    }
     if (!raw.response) {
       raw.response = {};
     }
@@ -35,6 +41,9 @@ function setRawDefaults(raw) {
     }
     if (typeof raw.expects.exercised === 'undefined') {
       raw.expects.exercised = true;
+    }
+    if (!raw.exceptions.checkExercised) {
+      raw.expects.exercised = false;
     }
   }
 }
@@ -178,6 +187,12 @@ class InteractionExpectations {
   }
 }
 
+class InteractionExceptions {
+  constructor(exceptions) {
+    this.checkExercised = exceptions.checkExercised;
+  }
+}
+
 class Interaction {
   constructor(raw) {
     let unprocessedResponse;
@@ -204,6 +219,7 @@ class Interaction {
       response,
       expects,
       stores,
+      exceptions
     } = raw;
     this.id = id || helper.getRandomId();
     if (flow) this.flow = flow;
@@ -213,6 +229,7 @@ class Interaction {
     this.request = new InteractionRequest(request);
     this.response = setResponse(response);
     this.expects = new InteractionExpectations(expects);
+    this.exceptions = new InteractionExceptions(exceptions);
     if (stores && typeof stores === 'object') {
       this.stores = stores;
     }

--- a/src/models/Interaction.model.js
+++ b/src/models/Interaction.model.js
@@ -24,12 +24,6 @@ function setRawDefaults(raw) {
     if (typeof raw.strict === 'undefined') {
       raw.strict = true;
     }
-    if (!raw.exceptions) {
-      raw.exceptions = { checkExercised: true };
-    }
-    if (typeof raw.exceptions.checkExercised === 'undefined') {
-      raw.exceptions.checkExercised = true;
-    }
     if (!raw.response) {
       raw.response = {};
     }
@@ -37,12 +31,15 @@ function setRawDefaults(raw) {
       if (typeof raw.response.status === 'undefined') raw.response.status = 404;
     }
     if (!raw.expects) {
-      raw.expects = { exercised: true };
+      raw.expects = { disable: false, exercised: true };
     }
     if (typeof raw.expects.exercised === 'undefined') {
       raw.expects.exercised = true;
     }
-    if (!raw.exceptions.checkExercised) {
+    if (typeof raw.expects.disable === 'undefined') {
+      raw.expects.disable = false;
+    }
+    if (raw.expects.disable) {
       raw.expects.exercised = false;
     }
   }
@@ -182,14 +179,9 @@ class InteractionResponseDelay {
 
 class InteractionExpectations {
   constructor(expects) {
+    this.disable = expects.disable;
     this.exercised = expects.exercised;
     this.callCount = expects.callCount;
-  }
-}
-
-class InteractionExceptions {
-  constructor(exceptions) {
-    this.checkExercised = exceptions.checkExercised;
   }
 }
 
@@ -218,8 +210,7 @@ class Interaction {
       request,
       response,
       expects,
-      stores,
-      exceptions
+      stores
     } = raw;
     this.id = id || helper.getRandomId();
     if (flow) this.flow = flow;
@@ -229,7 +220,6 @@ class Interaction {
     this.request = new InteractionRequest(request);
     this.response = setResponse(response);
     this.expects = new InteractionExpectations(expects);
-    this.exceptions = new InteractionExceptions(exceptions);
     if (stores && typeof stores === 'object') {
       this.stores = stores;
     }

--- a/src/models/expect.js
+++ b/src/models/expect.js
@@ -78,19 +78,19 @@ class Expect {
         headers: interaction.request.headers,
         body: interaction.request.body
       };
-      if (!interaction.exceptions.checkExercised) {
-        log.debug('Interaction Exercised Check Skipped', intReq);
+      if (expects.disable) {
+        log.debug('Interaction expect exercised is skipped', intReq);
       }
-      if (expects.exercised && !interaction.exercised && interaction.exceptions.checkExercised) {
+      if (expects.exercised && !interaction.exercised && !expects.disable) {
         log.warn('Interaction Not Exercised', intReq);
         this.fail(`Interaction not exercised: ${interaction.request.method} - ${interaction.request.path}`);
       }
-      if (!expects.exercised && interaction.exercised && interaction.exceptions.checkExercised) {
+      if (!expects.exercised && interaction.exercised && !expects.disable) {
         log.warn('Interaction got Exercised', intReq);
         this.fail(`Interaction exercised: ${interaction.request.method} - ${interaction.request.path}`);
       }
       if (typeof expects.callCount !== 'undefined') {
-        if (expects.callCount !== interaction.callCount && interaction.exceptions.checkExercised) {
+        if (expects.callCount !== interaction.callCount && !expects.disable) {
           this.fail(`Interaction call count ${interaction.callCount} !== ${expects.callCount} for ${interaction.request.method} - ${interaction.request.path}`);
         }
       }

--- a/src/models/expect.js
+++ b/src/models/expect.js
@@ -78,16 +78,19 @@ class Expect {
         headers: interaction.request.headers,
         body: interaction.request.body
       };
-      if (expects.exercised && !interaction.exercised) {
+      if (!interaction.exceptions.checkExercised) {
+        log.debug('Interaction Exercised Check Skipped', intReq);
+      }
+      if (expects.exercised && !interaction.exercised && interaction.exceptions.checkExercised) {
         log.warn('Interaction Not Exercised', intReq);
         this.fail(`Interaction not exercised: ${interaction.request.method} - ${interaction.request.path}`);
       }
-      if (!expects.exercised && interaction.exercised) {
+      if (!expects.exercised && interaction.exercised && interaction.exceptions.checkExercised) {
         log.warn('Interaction got Exercised', intReq);
         this.fail(`Interaction exercised: ${interaction.request.method} - ${interaction.request.path}`);
       }
       if (typeof expects.callCount !== 'undefined') {
-        if (expects.callCount !== interaction.callCount) {
+        if (expects.callCount !== interaction.callCount && interaction.exceptions.checkExercised) {
           this.fail(`Interaction call count ${interaction.callCount} !== ${expects.callCount} for ${interaction.request.method} - ${interaction.request.path}`);
         }
       }

--- a/test/component/interactions.spec.js
+++ b/test/component/interactions.spec.js
@@ -826,9 +826,9 @@ describe('Pact - VALID', () => {
 });
 
 
-describe('Interactions - Exceptions check', () => {
+describe('Interactions - expects skip check', () => {
 
-  it('skip checkExercised - defaults', async () => {
+  it('skip expects - defaults', async () => {
     await pactum.spec()
       .useInteraction([{
         request: {
@@ -847,15 +847,13 @@ describe('Interactions - Exceptions check', () => {
         stores: {
           ProjectId: 'req.pathParams.id'
         },
-        exceptions: {
-          checkExercised: false
-        },
         expects: {
+          disable: true,
           exercised: true,
           callCount: 1
         }
-      }
-        , {
+      },
+      {
         request: {
           method: 'GET',
           path: '/api/users/{id}',
@@ -881,7 +879,7 @@ describe('Interactions - Exceptions check', () => {
       .toss();
   });
 
-  it('skip checkExercised (false) - failure', async () => {
+  it('skip expects (false) - failure', async () => {
     try {
       await pactum.spec()
         .useInteraction([{
@@ -901,8 +899,8 @@ describe('Interactions - Exceptions check', () => {
           stores: {
             ProjectId: 'req.pathParams.id'
           },
-          exceptions: {
-            checkExercised: true
+          expects: {
+            disable: false
           }
         },
         {
@@ -922,8 +920,9 @@ describe('Interactions - Exceptions check', () => {
           stores: {
             UserId: 'req.pathParams.id'
           },
-          exceptions: {
-            checkExercised: true
+          expects: {
+            exercised: true,
+            callCount: 1
           }
         }])
         .get('http://localhost:9393/api/users/1')

--- a/test/component/interactions.spec.js
+++ b/test/component/interactions.spec.js
@@ -1,6 +1,7 @@
 const { like, eachLike, regex } = require('pactum-matchers');
 const pactum = require('../../src/index');
 const FormData = require('form-data-lite');
+const { expect } = require('chai');
 
 describe('Mock', () => {
 
@@ -822,4 +823,117 @@ describe('Pact - VALID', () => {
       .toss();
   });
 
+});
+
+
+describe('Interactions - Exceptions check', () => {
+
+  it('skip checkExercised - defaults', async () => {
+    await pactum.spec()
+      .useInteraction([{
+        request: {
+          method: 'GET',
+          path: '/api/projects/{id}',
+          pathParams: {
+            id: '101'
+          }
+        },
+        response: {
+          status: 200,
+          body: {
+            id: '$S{ProjectId}'
+          }
+        },
+        stores: {
+          ProjectId: 'req.pathParams.id'
+        },
+        exceptions: {
+          checkExercised: false
+        },
+        expects: {
+          exercised: true,
+          callCount: 1
+        }
+      }
+        , {
+        request: {
+          method: 'GET',
+          path: '/api/users/{id}',
+          pathParams: {
+            id: '1'
+          }
+        },
+        response: {
+          status: 200,
+          body: {
+            id: '$S{UserId}'
+          }
+        },
+        stores: {
+          UserId: 'req.pathParams.id'
+        }
+      }])
+      .get('http://localhost:9393/api/users/1')
+      .expectStatus(200)
+      .expectJsonLike({
+        id: '1'
+      })
+      .toss();
+  });
+
+  it('skip checkExercised (false) - failure', async () => {
+    try {
+      await pactum.spec()
+        .useInteraction([{
+          request: {
+            method: 'GET',
+            path: '/api/projects/{id}',
+            pathParams: {
+              id: '101'
+            }
+          },
+          response: {
+            status: 200,
+            body: {
+              id: '$S{ProjectId}'
+            }
+          },
+          stores: {
+            ProjectId: 'req.pathParams.id'
+          },
+          exceptions: {
+            checkExercised: true
+          }
+        },
+        {
+          request: {
+            method: 'GET',
+            path: '/api/users/{id}',
+            pathParams: {
+              id: '1'
+            }
+          },
+          response: {
+            status: 200,
+            body: {
+              id: '$S{UserId}'
+            }
+          },
+          stores: {
+            UserId: 'req.pathParams.id'
+          },
+          exceptions: {
+            checkExercised: true
+          }
+        }])
+        .get('http://localhost:9393/api/users/1')
+        .expectStatus(200)
+        .expectJsonLike({
+          id: '1'
+        })
+    } catch (error) {
+      err = error;
+    }
+    expect(err.message).contains('Interaction not exercised: GET - /api/projects/{id}');
+  });
 });

--- a/test/component/remote.server.spec.js
+++ b/test/component/remote.server.spec.js
@@ -156,11 +156,8 @@ describe('Remote Server - before and after spec', () => {
       response: { status: 200, "matchingRules": {} },
       callCount: 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
-      expects: { exercised: true }
+      expects: { disable: false, exercised: true }
     });
   });
 
@@ -197,11 +194,8 @@ describe('Remote Server - before and after spec', () => {
         response: { status: 200, "matchingRules": {} },
         callCount: 0,
         "calls": [],
-        "exceptions": {
-          "checkExercised": true
-        },
         "exercised": false,
-        expects: { exercised: true }
+        expects: { disable: false, exercised: true }
       },
       {
         id: 'id2',
@@ -210,11 +204,8 @@ describe('Remote Server - before and after spec', () => {
         response: { status: 200, "matchingRules": {} },
         callCount: 0,
         "calls": [],
-        "exceptions": {
-          "checkExercised": true
-        },
         "exercised": false,
-        expects: { exercised: true }
+        expects: { disable: false, exercised: true }
       }
     ]);
   });
@@ -243,11 +234,8 @@ describe('Remote Server - before and after spec', () => {
         response: { status: 200, "matchingRules": {} },
         callCount: 0,
         "calls": [],
-        "exceptions": {
-          "checkExercised": true
-        },
         "exercised": false,
-        expects: { exercised: true }
+        expects: { disable: false, exercised: true }
       },
       {
         id: 'id2',
@@ -256,11 +244,8 @@ describe('Remote Server - before and after spec', () => {
         response: { status: 200, "matchingRules": {} },
         callCount: 0,
         "calls": [],
-        "exceptions": {
-          "checkExercised": true
-        },
         "exercised": false,
-        expects: { exercised: true }
+        expects: { disable: false, exercised: true }
       }
     ]);
   });

--- a/test/component/remote.server.spec.js
+++ b/test/component/remote.server.spec.js
@@ -156,6 +156,9 @@ describe('Remote Server - before and after spec', () => {
       response: { status: 200, "matchingRules": {} },
       callCount: 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       expects: { exercised: true }
     });
@@ -194,6 +197,9 @@ describe('Remote Server - before and after spec', () => {
         response: { status: 200, "matchingRules": {} },
         callCount: 0,
         "calls": [],
+        "exceptions": {
+          "checkExercised": true
+        },
         "exercised": false,
         expects: { exercised: true }
       },
@@ -204,6 +210,9 @@ describe('Remote Server - before and after spec', () => {
         response: { status: 200, "matchingRules": {} },
         callCount: 0,
         "calls": [],
+        "exceptions": {
+          "checkExercised": true
+        },
         "exercised": false,
         expects: { exercised: true }
       }
@@ -234,6 +243,9 @@ describe('Remote Server - before and after spec', () => {
         response: { status: 200, "matchingRules": {} },
         callCount: 0,
         "calls": [],
+        "exceptions": {
+          "checkExercised": true
+        },
         "exercised": false,
         expects: { exercised: true }
       },
@@ -244,6 +256,9 @@ describe('Remote Server - before and after spec', () => {
         response: { status: 200, "matchingRules": {} },
         callCount: 0,
         "calls": [],
+        "exceptions": {
+          "checkExercised": true
+        },
         "exercised": false,
         expects: { exercised: true }
       }

--- a/test/component/remote.spec.js
+++ b/test/component/remote.spec.js
@@ -43,9 +43,6 @@ describe('Remote- post single mock interaction', () => {
           "callCount": 0,
           "exercised": false,
           "calls": [],
-          "exceptions": {
-            "checkExercised": true
-          },
           id,
           "strict": true,
           "request": {
@@ -66,6 +63,7 @@ describe('Remote- post single mock interaction', () => {
             }
           },
           "expects": {
+            "disable": false,
             "exercised": true
           }
         }
@@ -82,9 +80,6 @@ describe('Remote- post single mock interaction', () => {
           "callCount": 0,
           "exercised": false,
           "calls": [],
-          "exceptions": {
-            "checkExercised": true
-          },
           id,
           "strict": true,
           "request": {
@@ -105,6 +100,7 @@ describe('Remote- post single mock interaction', () => {
             }
           },
           "expects": {
+            "disable": false,
             "exercised": true
           }
         }
@@ -146,9 +142,6 @@ describe('Remote- post single mock interaction', () => {
               "exercisedAt": "123456"
             }
           ],
-          "exceptions": {
-            "checkExercised": true
-          },
           id,
           "strict": true,
           "request": {
@@ -169,6 +162,7 @@ describe('Remote- post single mock interaction', () => {
             }
           },
           "expects": {
+            "disable": false,
             "exercised": true
           }
         }

--- a/test/component/remote.spec.js
+++ b/test/component/remote.spec.js
@@ -43,6 +43,9 @@ describe('Remote- post single mock interaction', () => {
           "callCount": 0,
           "exercised": false,
           "calls": [],
+          "exceptions": {
+            "checkExercised": true
+          },
           id,
           "strict": true,
           "request": {
@@ -79,6 +82,9 @@ describe('Remote- post single mock interaction', () => {
           "callCount": 0,
           "exercised": false,
           "calls": [],
+          "exceptions": {
+            "checkExercised": true
+          },
           id,
           "strict": true,
           "request": {
@@ -140,6 +146,9 @@ describe('Remote- post single mock interaction', () => {
               "exercisedAt": "123456"
             }
           ],
+          "exceptions": {
+            "checkExercised": true
+          },
           id,
           "strict": true,
           "request": {

--- a/test/unit/interaction.spec.js
+++ b/test/unit/interaction.spec.js
@@ -27,19 +27,13 @@ describe('Interaction', () => {
           id: 1,
           name: 'fake'
         }
-      },
-      exceptions: {
-        checkExercised: false
-      },
+      }
     };
     const interaction = new Interaction(raw, true);
     expect(interaction).to.deep.equals({
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": false
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -60,7 +54,8 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
-        "exercised": false,
+        "disable": false,
+        "exercised": true,
         "callCount": undefined
       }
     });
@@ -93,9 +88,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -119,6 +111,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -152,9 +145,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -186,6 +176,7 @@ describe('Interaction', () => {
         }
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -219,9 +210,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -247,6 +235,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -280,9 +269,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -316,6 +302,7 @@ describe('Interaction', () => {
         }
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -333,8 +320,6 @@ describe('Interaction', () => {
     };
     const interaction = new Interaction(raw, true);
     expect(interaction.request).deep.equals({
-
-
       "method": "GET",
       "path": "/api/projects/1",
       "queryParams": {},
@@ -366,9 +351,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -395,6 +377,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -428,9 +411,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -459,6 +439,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -493,9 +474,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -522,6 +500,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -551,9 +530,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -581,6 +557,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -609,9 +586,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -632,6 +606,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }
@@ -651,9 +626,6 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
-      "exceptions": {
-        "checkExercised": true
-      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -669,6 +641,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
+        "disable": false,
         "exercised": true,
         "callCount": undefined
       }

--- a/test/unit/interaction.spec.js
+++ b/test/unit/interaction.spec.js
@@ -27,13 +27,19 @@ describe('Interaction', () => {
           id: 1,
           name: 'fake'
         }
-      }
+      },
+      exceptions: {
+        checkExercised: false
+      },
     };
     const interaction = new Interaction(raw, true);
     expect(interaction).to.deep.equals({
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": false
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -54,7 +60,7 @@ describe('Interaction', () => {
         "matchingRules": {}
       },
       "expects": {
-        "exercised": true,
+        "exercised": false,
         "callCount": undefined
       }
     });
@@ -87,6 +93,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -143,6 +152,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -207,6 +219,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -265,6 +280,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -348,6 +366,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -407,6 +428,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -469,6 +493,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -524,6 +551,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -579,6 +609,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {
@@ -618,6 +651,9 @@ describe('Interaction', () => {
       "id": "random",
       "callCount": 0,
       "calls": [],
+      "exceptions": {
+        "checkExercised": true
+      },
       "exercised": false,
       "strict": true,
       "response": {


### PR DESCRIPTION
Closes #105 

Changes:

- Added a new property to the interaction object
  ```js
  exceptions: {
     checkExercised: true    // default
  }
  ```
- Works with `interaction handlers`, `useInteraction`, `addInteraction`
- Unit & Component test update.
- Bump `pactum-matchers` version to `1.0.6`
- Bump `pactum` version to `3.1.2`
