### PR TITLE
Add support for setting mock server host address

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 const config = {
   mock: {
     port: process.env.PACTUM_MOCK_PORT || 9393,
+    host: process.env.PACTUM_MOCK_HOST || '0.0.0.0',
     remote: ''
   },
   request: {

--- a/src/exports/mock.d.ts
+++ b/src/exports/mock.d.ts
@@ -73,6 +73,7 @@ export interface Handler {
  */
 export function start(): Promise<void>;
 export function start(port: number): Promise<void>;
+export function start(port: number, host: string): Promise<void>;
 
 /**
  * stops the mock server

--- a/src/exports/mock.js
+++ b/src/exports/mock.js
@@ -10,10 +10,8 @@ const mock = {
 
   _server: new Server(),
 
-  start(port) {
-    if (port) {
-      this.setDefaultPort(port);
-    }
+  start(port, host) {
+    this.setDefaults(port, host)
     return this._server.start();
   },
 
@@ -21,11 +19,19 @@ const mock = {
     return this._server.stop();
   },
 
-  setDefaultPort(port) {
-    if (typeof port !== 'number') {
+  setDefaults(port, host) {
+    if (port && typeof port !== 'number') {
       throw new PactumConfigurationError(`Invalid port number provided - ${port}`);
     }
-    config.mock.port = port;
+    if (host && typeof host !== 'string') {
+      throw new PactumConfigurationError(`Invalid host provided - ${host}`);
+    }
+    if (port) {
+      config.mock.port = port;
+    }
+    if (host) {
+      config.mock.host = host;
+    }
   },
 
   addInteraction(interactions, data) {

--- a/src/models/server.js
+++ b/src/models/server.js
@@ -25,8 +25,9 @@ class Server {
         this.app.use(bodyParser);
         registerPactumRemoteRoutes(this);
         registerAllRoutes(this, this.app);
-        this.app.listen(config.mock.port, () => {
-          log.info(`Mock server is listening on port ${config.mock.port}`);
+        this.app.listen(config.mock.port, config.mock.host, () => {
+          const mockAddrInfo = this.app.server.address()
+          log.info(`Mock server is listening on http://${mockAddrInfo.address}:${mockAddrInfo.port}`);
           this._registerEvents();
           resolve();
         });

--- a/test/unit/mock.spec.js
+++ b/test/unit/mock.spec.js
@@ -31,6 +31,34 @@ describe('Mock', () => {
     expect(() => mock.start({})).throws('Invalid port number provided');
   });
 
+  it('start with port & host - 127.0.0.1', async () => {
+    await mock.start(3000, '127.0.0.1');
+    expect(this.serverStartStub.callCount).equals(1, 'should start the server');
+  });
+
+  it('start with port & host - 0.0.0.0', async () => {
+    await mock.start(3000, '0.0.0.0');
+    expect(this.serverStartStub.callCount).equals(1, 'should start the server');
+  });
+
+  it('start with port & host - localhost', async () => {
+    await mock.start(3000, 'localhost');
+    expect(this.serverStartStub.callCount).equals(1, 'should start the server');
+  });
+
+  it('start with port & host - localhost', async () => {
+    await mock.start(3000, 'localhost');
+    expect(this.serverStartStub.callCount).equals(1, 'should start the server');
+  });
+
+  it('start with port & invalid host', async () => {
+    expect(() => mock.start(3000, 100)).throws('Invalid host provided - 100');
+  });
+
+  it('start with invalid port & valid host', async () => {
+    expect(() => mock.start('3000', 'localhost')).throws('Invalid port number provided - 3000');
+  });
+
   it('stop', async () => {
     await mock.stop();
     expect(this.serverStopStub.callCount).equals(1, 'should stop the server');


### PR DESCRIPTION
**Changes:**

This PR adds additional support to the request: https://github.com/pactumjs/pactum/issues/119

_Enhancement:_

- Update console log when mock server starts to include address and port (ex: http://127.0.0.1:3000)
  - `[I] Mock server is listening on http://127.0.0.1:3000`
- Add support to set mock server's host address (defaults to `0.0.0.0` to listen on all interfaces)
Usage:
```js
mock.start()                       // Runs on all interfaces & port :9393
mock.start(3000)                   // Runs on all interfaces & port :3000 
mock.start(3000, '127.0.0.1')    // Runs on 127.0.0.1:3000 or localhost:3000
```