### PR TITLE
feat: add generics support for specs

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,7 +30,7 @@ export function spec(): Spec;
  *  .use('spec handler name', { optional: 'data' })
  *  .expectStatus(200);
  */
-export function spec(name: string, data?: any): Spec;
+export function spec<T = any>(name: string, data?: T): Spec;
 
 /**
  * returns an instance of spec

--- a/src/models/Step.d.ts
+++ b/src/models/Step.d.ts
@@ -8,7 +8,7 @@ declare class StepSpec extends Spec {
 
 declare class Step {
   spec<T = any>(name?: string, data?: T): StepSpec;
-  clean(name?: string, data?: any): CleanStep;
+  clean<T = any>(name?: string, data?: T): CleanStep;
   toss(): Promise<void>;
 }
 

--- a/src/models/Step.d.ts
+++ b/src/models/Step.d.ts
@@ -7,7 +7,7 @@ declare class StepSpec extends Spec {
 }
 
 declare class Step {
-  spec(name?: string, data?: any): StepSpec;
+  spec<T = any>(name?: string, data?: T): StepSpec;
   clean(name?: string, data?: any): CleanStep;
   toss(): Promise<void>;
 }


### PR DESCRIPTION
The `spec` methods can now be used with generics to add better type support for the `data` parameter. Now instead of being typed as `any`, the default is still `any`, but a developer can do `spec<SomeInterface>('spec name', objectThatAdheresToSomeInterface)` and get Typescript support if the passed data is incorrect in any way