### PR TITLE
fix: GraphQLRequest variables type

### DIFF
--- a/src/exports/mock.d.ts
+++ b/src/exports/mock.d.ts
@@ -2,7 +2,7 @@ export type RequestMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD'
 
 export interface GraphQLRequest {
   query: string;
-  variables?: string;
+  variables?: object;
 }
 
 export interface InteractionRequest {


### PR DESCRIPTION
Fixes #162

I used the type object to use the same as another object types.