### PR TITLE
Fix type definitions for expect.d.ts

### DIFF
--- a/src/exports/expect.d.ts
+++ b/src/exports/expect.d.ts
@@ -1,4 +1,4 @@
-interface Have {
+export interface Have {
   status(code: number): void;
   header(key: string, value: any): void;
   headerContains(key: string, value: any): void;
@@ -25,15 +25,13 @@ interface Have {
   _(handler: string, data: any): Promise<void>;
 }
 
-interface To {
+export interface To {
   have: Have;
 }
 
-interface Expect {
+export interface Expect {
   to: To;
   should: To;
 }
 
-declare function expect(response: any): Expect;
-
-export = expect;
+export default function expect(response: any, spec: any): Expect;


### PR DESCRIPTION
In the file `src/models/Spec.d.ts` there is an import:

```
import { Expect } from '../exports/expect';
```

However `src/exports/expect.d.ts` doesn't have a _named_ export called
`Expect` because it's not imported. This should fix that.

Also: I noticed that the default export function in the JS code takes an extra parameter called `spec`, so I added those as well with a rather broad `any` type though.

--

I would like to have this fixed because it fails the linting rules at the moment:

```typescript
  this.lastRequest.response().should.have.status(201);
```

Where `this.lastRequest` is a `Spec`. So `this.lastRequest.response()` gives an `Expect`, but it doesn't really know what type it is because of the wrong type definitions. Therefore the linter fails with the fact that `should` is called on an `any` type.

```
       Linting "flow-tests"...

       .../apps/flow-tests/steps/carrier-steps.ts
         80:5  error  Unsafe member access .should on an `any` value  @typescript-eslint/no-unsafe-member-access
         80:5  error  Unsafe call of an `any` typed value             @typescript-eslint/no-unsafe-call
```