### PR TITLE
Fix type defitions for Spec#returns

### DIFF
--- a/src/models/Spec.d.ts
+++ b/src/models/Spec.d.ts
@@ -110,7 +110,7 @@ declare class Spec {
   withPath(url: string): Spec;
 
   /**
-   * replaces path params in the request url 
+   * replaces path params in the request url
    * @see https://pactumjs.github.io/api/requests/withPathParams.html
    */
   withPathParams(key: string, value: any): Spec;
@@ -358,9 +358,9 @@ declare class Spec {
    * returns custom response from json response using custom handler
    * @see https://pactumjs.github.io/api/requests/returns.html
    */
-  returns(handlerName: string): Spec;
-  returns(path: string): Spec;
-  returns(handler: CaptureHandlerFunction): Spec;
+  returns<T = Spec>(handlerName: string): T;
+  returns<T = Spec>(path: string): T;
+  returns<T = Spec>(handler: CaptureHandlerFunction): T;
 
   /**
    * records data that will be available in reports


### PR DESCRIPTION
Reading through the sources it seems to me that `Spec#returns(...)` will
either return something directly or (if the response is not yet there)
it will continue building the spec. This is not shown in the type
definitions.

In this way you can use it like this if you already have a response.

```
const x  = spec.returns<number>('res.body') // number
```

But will continue the spec if you don't give a type argument:

```
const x = spec.returns('res.body') // Spec
```