### PR TITLE
Add 'url' to the SpecRequest interface

### DIFF
--- a/src/exports/reporter.d.ts
+++ b/src/exports/reporter.d.ts
@@ -2,6 +2,7 @@ import { InteractionRequest, Interaction } from './mock';
 
 export interface SpecRequest {
   method: string;
+  url: string;
   path: string;
   headers?: object;
   body?: any;


### PR DESCRIPTION
The `url` property was missing from the SpecRequest type. I'm reasonably sure that it's always there, but I don't know all the use cases obviously. At the very least it should be an optional property. But again I think it's required: let me know otherwise.