### PR TITLE
fix: provide type definition for Spec.then method

### DIFF
--- a/src/models/Spec.d.ts
+++ b/src/models/Spec.d.ts
@@ -401,6 +401,14 @@ declare class Spec {
   toss(): Promise<IncomingMessage> | Promise<any>;
 
   /**
+   * supports promise chaining and await syntax
+   */
+  then(
+    onFulfilled: (value: any) => any,
+    onRejected: (reason: any) => any
+  ): Promise<any>;
+
+  /**
    * returns chai like assertions
    * @see https://pactumjs.github.io/api/assertions/response.html
    * @requires .toss() should be called beforehand.


### PR DESCRIPTION
This PR intends to resolve this issue: https://github.com/pactumjs/pactum/issues/199