### PR TITLE
feat(src/models/Spec.js): add withBearerToken method

### DIFF
--- a/src/models/Spec.d.ts
+++ b/src/models/Spec.d.ts
@@ -202,6 +202,12 @@ declare class Spec {
   withAuth(username: string, password: string): Spec;
 
   /**
+   * bearer token
+   * @see https://pactumjs.github.io/api/requests/withBearerToken.html
+   */
+  withBearerToken(token: string): Spec;
+
+  /**
    * basic auth
    * @see https://pactumjs.github.io/api/requests/withFollowRedirects.html
    */

--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -288,6 +288,14 @@ class Spec {
     return this;
   }
 
+  withBearerToken(token) {
+    if (!this._request.headers) {
+      this._request.headers = {};
+    }
+    this._request.headers["Authorization"] = "Bearer " + token;
+    return this;
+  }
+
   withFollowRedirects(follow) {
     this._request.followRedirects = follow;
     return this;

--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -289,7 +289,7 @@ class Spec {
   }
 
   withBearerToken(token) {
-    if (typeof key !== 'string') {
+    if (typeof token !== 'string') {
       throw new PactumRequestError('`token` is required');
     }
     if (!this._request.headers) {

--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -289,6 +289,9 @@ class Spec {
   }
 
   withBearerToken(token) {
+    if (typeof key !== 'string') {
+      throw new PactumRequestError('`token` is required');
+    }
     if (!this._request.headers) {
       this._request.headers = {};
     }

--- a/test/component/withBearerToken.spec.js
+++ b/test/component/withBearerToken.spec.js
@@ -1,0 +1,68 @@
+const pactum = require('../../src/index');
+
+describe('withBearerToken', () => {
+
+  describe('should process', () => {
+    
+    it('with value', async () => {
+      await pactum.spec()
+        .useInteraction({
+          request: {
+            method: 'GET',
+            path: '/api/token',
+            headers:{
+              Authorization: "Bearer token"
+            }
+          },
+          response: {
+            status: 200
+          }
+        })
+        .get('http://localhost:9393/api/token')
+        .withBearerToken('token')
+        .expectStatus(200);
+    });
+    
+    it('without value', async () => {
+      await pactum.spec()
+        .useInteraction({
+          request: {
+            method: 'GET',
+            path: '/api/token',
+            headers:{
+              Authorization: "Bearer"
+            }
+          },
+          response: {
+            status: 200
+          }
+        })
+        .get('http://localhost:9393/api/token')
+        .withBearerToken('')
+        .expectStatus(200);
+    });
+
+    it('with duplicate value', async () => {
+      await pactum.spec()
+        .useInteraction({
+          strict: false,
+          request: {
+            method: 'GET',
+            path: '/api/token',
+            headers:{
+              Authorization: "Bearer duplicate"
+            }
+          },
+          response: {
+            status: 200
+          }
+        })
+        .get('http://localhost:9393/api/token')
+        .withBearerToken('token')
+        .withBearerToken('duplicate')
+        .expectStatus(200);
+    });
+  
+  });
+  
+});

--- a/test/unit/spec.spec.js
+++ b/test/unit/spec.spec.js
@@ -142,6 +142,28 @@ describe('Spec', () => {
     expect(err.toString()).equals('Error: `headers` are required');
   });
 
+  it('withBearerToken - invalid', () => {
+    let err;
+    try {
+      const spec = new Spec();
+      spec.withBearerToken();
+    } catch (error) {
+      err = error;
+    }
+    expect(err.toString()).equals('Error: `token` is required');
+  });
+
+  it('withBearerToken - null', () => {
+    let err;
+    try {
+      const spec = new Spec();
+      spec.withBearerToken(null);
+    } catch (error) {
+      err = error;
+    }
+    expect(err.toString()).equals('Error: `token` is required');
+  });
+
   it('toss - without url', async () => {
     let err;
     try {


### PR DESCRIPTION
add withBearerToken method to Spec to set the bearer token in the request

- Before
 ```javascript
      // ...
      await spec
        .get('/')
        .withHeaders("Authorization", `Bearer ${token}`)
      // ...
 ```
- After
 ```javascript
      // ...
      await spec
        .get('/')
        .withBearerToken(token)
      // ...
 ```