### PR TITLE
Made pactum-matchers a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "klona": "^2.0.6",
         "lightcookie": "^1.0.25",
         "openapi-fuzzer-core": "^1.0.6",
-        "pactum-matchers": "^1.1.6",
         "parse-graphql": "^1.0.0",
         "phin": "^3.7.0",
         "polka": "^0.5.2"
@@ -29,6 +28,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "pactum-matchers": "^1.1.6"
       }
     },
     "node_modules/@arr/every": {
@@ -2310,7 +2312,8 @@
     "node_modules/pactum-matchers": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/pactum-matchers/-/pactum-matchers-1.1.6.tgz",
-      "integrity": "sha512-55io32NeOKbLpHKKPzYDOr+N2dseTzMbj1Gj1y+zvOkKK6NDf5BT5pxglfqLN/ra3ig5zvbrKFUqZIWjAWboog=="
+      "integrity": "sha512-55io32NeOKbLpHKKPzYDOr+N2dseTzMbj1Gj1y+zvOkKK6NDf5BT5pxglfqLN/ra3ig5zvbrKFUqZIWjAWboog==",
+      "peer": true
     },
     "node_modules/parse-graphql": {
       "version": "1.0.0",
@@ -4729,7 +4732,8 @@
     "pactum-matchers": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/pactum-matchers/-/pactum-matchers-1.1.6.tgz",
-      "integrity": "sha512-55io32NeOKbLpHKKPzYDOr+N2dseTzMbj1Gj1y+zvOkKK6NDf5BT5pxglfqLN/ra3ig5zvbrKFUqZIWjAWboog=="
+      "integrity": "sha512-55io32NeOKbLpHKKPzYDOr+N2dseTzMbj1Gj1y+zvOkKK6NDf5BT5pxglfqLN/ra3ig5zvbrKFUqZIWjAWboog==",
+      "peer": true
     },
     "parse-graphql": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "klona": "^2.0.6",
     "lightcookie": "^1.0.25",
     "openapi-fuzzer-core": "^1.0.6",
-    "pactum-matchers": "^1.1.6",
     "parse-graphql": "^1.0.0",
     "phin": "^3.7.0",
     "polka": "^0.5.2"
@@ -69,6 +68,9 @@
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "sinon": "^15.2.0"
+  },
+  "peerDependencies": {
+    "pactum-matchers": "^1.1.6"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
This PR makes `pactum-matchers` a `peerDependency`. By making `pactum-matchers` a peer dependency, it's possible to install a custom fork of `pactum-matchers` and have it favoured over the version that is installed by `pactum` as default. This makes forking and adding new matchers easier.