### PR TITLE
Modified data processor functional param splitting logic

### DIFF
--- a/src/helpers/dataProcessor.js
+++ b/src/helpers/dataProcessor.js
@@ -101,7 +101,7 @@ const dataProcessor = {
           values.push(typeof value === 'undefined' ? raw : value);
         }
         if (refType === 'F') {
-          const [handlerName, ..._args] = refValue.split(':');
+          const [handlerName, ..._args] = refValue.split(/:(.*)/);
           const handlerFun = handler.getDataFuncHandler(handlerName);
           const handler_data = handlerFun({ args: _args.length > 0 ? _args[0].split(',') : _args });
           values.push(this.processDataRefs(handler_data));

--- a/test/unit/dataProcessor.spec.js
+++ b/test/unit/dataProcessor.spec.js
@@ -963,6 +963,24 @@ describe('Data Processing - Functions', () => {
     expect(data).deep.equals({ name: 'Jon' });
   });
 
+  it('should return data passed in as parameter', () => {
+    handler.addDataFuncHandler('GetParam', (ctx) => {
+      return ctx.args[0]
+    });
+
+    const data = dp.processData('$F{GetParam:Jon}');
+    expect(data).equals('Jon');
+  });
+
+  it('should return data passed in as parameter with semicolon', () => {
+    handler.addDataFuncHandler('GetParam', (ctx) => {
+      return ctx.args[0]
+    });
+
+    const data = dp.processData('$F{GetParam:Jon:Doe}');
+    expect(data).equals('Jon:Doe');
+  });
+
   afterEach(() => {
     config.data.ref.map.enabled = false;
     config.data.ref.map.processed = false;


### PR DESCRIPTION
Reference issue: #305 

When providing parameters to function mapping (ie: `$F{sum:1,2}`), if the parameter includes a : character, the rest of the parameter is cut off from being included in the arguments.

In dataProcessor.js line 104, the `FunctionName:param1,param2` string is being split up by the : character for all instances of the character, causing arguments which include a : to be split and not passed to the function when it is filtered out on line 106.

I modified the behavior by changing the `refValue.split(':')` on line 104 to use a regex expression to only split by the first instance of the : character like so `refValue.split(/:(.*)/)` so params including the ':' character can be passed to functions 