### PR TITLE
Fix withCore overriding request core options when using withAuth

### DIFF
--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const lc = require('lightcookie');
-
+const override = require('deep-override');
 const path = require('path');
 const Tosser = require('./Tosser');
 const Expect = require('./expect');
@@ -284,7 +284,8 @@ class Spec {
   }
 
   withCore(options) {
-    this._request.core = options;
+    this._request.core = this._request.core || {};
+    override(this._request.core, options);
     return this;
   }
 

--- a/test/component/interactions.spec.js
+++ b/test/component/interactions.spec.js
@@ -650,7 +650,7 @@ describe('Mock', () => {
       .expectStatus(200);
   });
 
-  it.only('GET - with core options & auth - override with core invalid auth', async () => {
+  it('GET - with core options & auth - override with core invalid auth', async () => {
     try {
       await pactum.spec()
       .useInteraction({

--- a/test/component/interactions.spec.js
+++ b/test/component/interactions.spec.js
@@ -604,6 +604,79 @@ describe('Mock', () => {
       .expectStatus(200);
   });
 
+  it('GET - with core options & auth - override with auth', async () => {
+    await pactum.spec()
+      .useInteraction({
+        request: {
+          method: 'GET',
+          path: '/api/core',
+          headers: {
+            'authorization': 'Basic dXNlcjpwYXNz'
+          }
+        },
+        response: {
+          status: 200
+        }
+      })
+      .get('http://localhost:9393')
+      .withCore({
+        path: '/api/core',
+        auth: 'user:invalid-pass'
+      })
+      .withAuth('user', 'pass')
+      .expectStatus(200);
+  });
+
+  it('GET - with core options & auth - override with core', async () => {
+    await pactum.spec()
+      .useInteraction({
+        request: {
+          method: 'GET',
+          path: '/api/core',
+          headers: {
+            'authorization': 'Basic dXNlcjpwYXNz'
+          }
+        },
+        response: {
+          status: 200
+        }
+      })
+      .get('http://localhost:9393')
+      .withAuth('user', 'invalid-pass')
+      .withCore({
+        path: '/api/core',
+        auth: 'user:pass'
+      })
+      .expectStatus(200);
+  });
+
+  it.only('GET - with core options & auth - override with core invalid auth', async () => {
+    try {
+      await pactum.spec()
+      .useInteraction({
+        request: {
+          method: 'GET',
+          path: '/api/core',
+          headers: {
+            'authorization': 'Basic dXNlcjpwYXNz'
+          }
+        },
+        response: {
+          status: 200
+        }
+      })
+      .get('http://localhost:9393')
+      .withAuth('user', 'pass')
+      .withCore({
+        path: '/api/core',
+        auth: 'user:invalid-pass'
+      })
+    } catch (error) {
+      err = error
+    }
+    expect(err.message).contains('Interaction not exercised: GET - /api/core');
+  });
+
   it('GET - with auth', async () => {
     await pactum.spec()
       .useInteraction({


### PR DESCRIPTION
**Summary**

- Closes #344 
- withCore method was overriding the core options of request object, fix is to extend/override using `deep-override` instead of direct assignment.
- After this fix`withCore` and `withAuth` sequence in chaining can be shuffled.

> Note: if `withCore` is used at the end of the request chaining, options in `withCore` (if provided) will override in http request.