### PR TITLE
Merged removeDefaultHeader and removeDefaultHeaders methods into one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pactum",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pactum",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@exodus/schemasafe": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pactum",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "REST API Testing Tool for all levels in a Test Pyramid",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/src/exports/request.d.ts
+++ b/src/exports/request.d.ts
@@ -28,7 +28,7 @@ export function setFollowRedirects(follow: boolean): void;
 /**
  * removes all or selective default headers
  */
-export function removeDefaultHeaders(key: string): void;
+export function removeDefaultHeaders(key?: string): void;
 
 /**
  * records data that will be available in reports

--- a/src/exports/request.d.ts
+++ b/src/exports/request.d.ts
@@ -26,14 +26,9 @@ export function setBaseUrl(url: string): void;
 export function setFollowRedirects(follow: boolean): void;
 
 /**
- * removes default header
+ * removes all or selective default headers
  */
-export function removeDefaultHeader(key: string): void;
-
-/**
- * removes all default headers
- */
-export function removeDefaultHeaders(): void;
+export function removeDefaultHeaders(key: string): void;
 
 /**
  * records data that will be available in reports

--- a/src/exports/request.js
+++ b/src/exports/request.js
@@ -46,15 +46,12 @@ const request = {
     config.request.followRedirects = follow;
   },
 
-  removeDefaultHeader(key) {
-    if (!key) {
-      throw new PactumRequestError(`Invalid header key provided - ${key}`);
-    }
-    delete config.request.headers[key];
-  },
-
-  removeDefaultHeaders() {
-    config.request.headers = {};
+  removeDefaultHeaders(key) {
+    if(key) {
+      delete config.request.headers[key];
+    } else {
+      config.request.headers = {};
+    } 
   },
 
   setDefaultRecorders(name, path) {

--- a/test/unit/request.spec.js
+++ b/test/unit/request.spec.js
@@ -21,12 +21,8 @@ describe('request', () => {
     expect(() => request.setDefaultHeaders()).throws('Invalid header key provided - undefined');
   });
 
-  it('removeDefaultHeader - undefined', () => {
-    expect(() => request.removeDefaultHeader()).throws('Invalid header key provided - undefined');
-  });
-
-  it('removeDefaultHeader - which is not present', () => {
-    request.removeDefaultHeader('present');
+  it('removeDefaultHeaders - which is not present', () => {
+    request.removeDefaultHeaders('present');
   });
 
   it('setDefaultHeader & setDefaultHeaders & remove', () => {
@@ -41,7 +37,7 @@ describe('request', () => {
       'no': 'space',
       'gta': 'v'
     });
-    request.removeDefaultHeader('no');
+    request.removeDefaultHeaders('no');
     expect(config.request.headers).deep.equals({
       'hello': 'space',
       'gta': 'v'
@@ -62,6 +58,35 @@ describe('request', () => {
     expect(() => request.setDefaultTimeout('100')).throws('Invalid timeout provided - 100');
   });
 
+  it('setting default headers and removing it', () => {
+    request.setDefaultHeaders({
+      'pactumjs': 'userfriendly',
+      'apitesting': 'pactumjs'
+    });
+    expect(config.request.headers).deep.equals({
+      'pactumjs': 'userfriendly',
+      'apitesting': 'pactumjs'
+    });
+    request.removeDefaultHeaders();
+    expect(config.request.headers).deep.equals({});
+  });
+
+  it('setting duplicate headers and removing it', () => {
+    request.setDefaultHeaders({
+      'pactumjs': 'lightweight',
+      'test': 'testing',
+      'test': 'tested'
+    });
+    expect(config.request.headers).deep.equals({
+      'pactumjs': 'lightweight',
+      'test': 'tested'
+    });
+    request.removeDefaultHeaders('test');
+    expect(config.request.headers).deep.equals({
+      'pactumjs': 'lightweight'
+    });
+  });
+  
   afterEach(() => {
    config.request.headers = {};
   });


### PR DESCRIPTION
Hi @ASaiAnudeep , the following changes are for Issue #365

Done the following:

1. Have merged removeDefaultHeader and removeDefaultHeaders into one method removeDefaultHeaders
2. If key is mentioned it will delete the particular default header else if nothing is mentioned will delete all the default 
    headers
3. Have removed one unit test due to the current changes, as now based on the truthiness of the key we are deciding what 
    action to be performed
4. Have added 2 unit tests
5. Added the doc for removeDefaultHeaders, PR link - https://github.com/pactumjs/pactumjs.github.io/pull/52

Please review the changes and do the needful. Thanks!
