### PR TITLE
Allow configuring follow redirects count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "openapi-fuzzer-core": "^1.0.6",
         "pactum-matchers": "^1.1.7",
         "parse-graphql": "^1.0.0",
-        "phin": "^3.7.0",
+        "phin": "^3.7.1",
         "polka": "^0.5.2"
       },
       "devDependencies": {
@@ -887,9 +887,13 @@
       "dev": true
     },
     "node_modules/centra": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/centra/-/centra-2.6.0.tgz",
-      "integrity": "sha512-dgh+YleemrT8u85QL11Z6tYhegAs3MMxsaWAq/oXeAmYJ7VxL3SI9TZtnfaEvNDMAPolj25FXIb3S+HCI4wQaQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+      "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6"
+      }
     },
     "node_modules/chai": {
       "version": "4.4.1",
@@ -1257,6 +1261,26 @@
       "dev": true,
       "bin": {
         "flat": "cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/foreground-child": {
@@ -2318,11 +2342,12 @@
       }
     },
     "node_modules/phin": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.0.tgz",
-      "integrity": "sha512-DqnVNrpYhKGBZppNKprD+UJylMeEKOZxHgPB+ZP6mGzf3uA2uox4Ep9tUm+rUc8WLIdHT3HcAE4X8fhwQA9JKg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+      "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
+      "license": "MIT",
       "dependencies": {
-        "centra": "^2.6.0"
+        "centra": "^2.7.0"
       },
       "engines": {
         "node": ">= 8"
@@ -3615,9 +3640,12 @@
       "dev": true
     },
     "centra": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/centra/-/centra-2.6.0.tgz",
-      "integrity": "sha512-dgh+YleemrT8u85QL11Z6tYhegAs3MMxsaWAq/oXeAmYJ7VxL3SI9TZtnfaEvNDMAPolj25FXIb3S+HCI4wQaQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+      "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+      "requires": {
+        "follow-redirects": "^1.15.6"
+      }
     },
     "chai": {
       "version": "4.4.1",
@@ -3894,6 +3922,11 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -4699,11 +4732,11 @@
       "dev": true
     },
     "phin": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.0.tgz",
-      "integrity": "sha512-DqnVNrpYhKGBZppNKprD+UJylMeEKOZxHgPB+ZP6mGzf3uA2uox4Ep9tUm+rUc8WLIdHT3HcAE4X8fhwQA9JKg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+      "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
       "requires": {
-        "centra": "^2.6.0"
+        "centra": "^2.7.0"
       }
     },
     "picomatch": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "openapi-fuzzer-core": "^1.0.6",
     "pactum-matchers": "^1.1.7",
     "parse-graphql": "^1.0.0",
-    "phin": "^3.7.0",
+    "phin": "^3.7.1",
     "polka": "^0.5.2"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,10 @@ const config = {
     baseUrl: process.env.PACTUM_REQUEST_BASE_URL || '',
     timeout: process.env.PACTUM_REQUEST_TIMEOUT ? parseInt(process.env.PACTUM_REQUEST_TIMEOUT) : 3000,
     headers: {},
-    followRedirects: false,
+    followRedirects: {
+      enabled: false,
+      count: 20
+    },
     retry: {
       count: 1,
       delay: 1000

--- a/src/exports/request.d.ts
+++ b/src/exports/request.d.ts
@@ -23,7 +23,8 @@ export function setBaseUrl(url: string): void;
 /**
  * sets default value for follow redirects
  */
-export function setFollowRedirects(follow: boolean): void;
+export function setDefaultFollowRedirects(follow: boolean): void;
+export function setDefaultFollowRedirects(follow: number): void;
 
 /**
  * removes all or selective default headers

--- a/src/exports/request.js
+++ b/src/exports/request.js
@@ -43,7 +43,13 @@ const request = {
   },
 
   setDefaultFollowRedirects(follow) {
-    config.request.followRedirects = follow;
+    if (typeof follow !== 'number' && typeof follow !== 'boolean') {
+      throw new PactumRequestError(`Invalid follow redirect option - ${follow}, allowed boolean/number`);
+    }
+    if (typeof follow == 'number' && follow >=0 ) {
+      config.request.followRedirects.count = follow;
+    }
+    config.request.followRedirects.enabled = follow;
   },
 
   removeDefaultHeaders(key) {

--- a/src/helpers/requestProcessor.js
+++ b/src/helpers/requestProcessor.js
@@ -153,8 +153,8 @@ function setMultiPartFormData(request) {
 }
 
 function setFollowRedirects(request) {
-  if (config.request.followRedirects && typeof request.followRedirects === 'undefined') {
-    request.followRedirects = config.request.followRedirects;
+  if (config.request.followRedirects.enabled && typeof request.followRedirects === 'undefined') {
+    request.followRedirects = config.request.followRedirects.count;
   }
 }
 

--- a/src/models/Spec.d.ts
+++ b/src/models/Spec.d.ts
@@ -217,7 +217,7 @@ declare class Spec {
    * @see https://pactumjs.github.io/api/requests/withFollowRedirects.html
    */
   withFollowRedirects(follow: boolean): Spec;
-
+  withFollowRedirects(follow: number): Spec;
   /**
    * enables compression
    * @see https://pactumjs.github.io/api/requests/withCompression.html

--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -321,8 +321,15 @@ class Spec {
   }
 
   withFollowRedirects(follow) {
+    if (typeof follow !== 'number' && typeof follow !== 'boolean') {
+      throw new PactumRequestError('Follow redirects should be number or boolean');
+    }
+    if (typeof follow == 'number' && follow >=0 ) {
+      this._request.followRedirects = follow;
+      return this;
+    }
     this._request.followRedirects = follow;
-    return this;
+    return this;   
   }
 
   withCompression() {

--- a/test/component/interactions.mock.spec.js
+++ b/test/component/interactions.mock.spec.js
@@ -498,7 +498,7 @@ describe('Interactions - Not Strict - Wait', () => {
 
 describe('Interactions - Not Strict - Follow Redirects', () => {
 
-  it('with Follow Redirects', async () => {
+  it('with Follow Redirects - boolean config', async () => {
     await pactum.spec()
       .useInteraction({
         strict: false,
@@ -525,6 +525,75 @@ describe('Interactions - Not Strict - Follow Redirects', () => {
       })
       .get('http://localhost:9393/mock/redirect')
       .withFollowRedirects(true)
+      .expectStatus(200);
+  });
+
+  it('with Follow Redirects - count config', async () => {
+    await pactum.spec()
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/redirect'
+        },
+        response: {
+          status: 301,
+          headers: {
+            'location': 'http://localhost:9393/mock/intermediate/1'
+          }
+        }
+      })
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/intermediate/1'
+        },
+        response: {
+          status: 301,
+          headers: {
+            'location': 'http://localhost:9393/mock/intermediate/2'
+          }
+        }
+      })
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/intermediate/2'
+        },
+        response: {
+          status: 301,
+          headers: {
+            'location': 'http://localhost:9393/mock/intermediate/3'
+          }
+        }
+      })
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/intermediate/3'
+        },
+        response: {
+          status: 301,
+          headers: {
+            'location': 'http://localhost:9393/mock/actual'
+          }
+        }
+      })
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/actual'
+        },
+        response: {
+          status: 200
+        }
+      })
+      .get('http://localhost:9393/mock/redirect')
+      .withFollowRedirects(4)
       .expectStatus(200);
   });
 
@@ -597,6 +666,36 @@ describe('Interactions - Not Strict - Follow Redirects', () => {
       .expectStatus(200);
   });
 
+  it('with default Follow Redirects - count config', async () => {
+    pactum.request.setDefaultFollowRedirects(1);
+    await pactum.spec()
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/redirect'
+        },
+        response: {
+          status: 301,
+          headers: {
+            'location': 'http://localhost:9393/mock/actual'
+          }
+        }
+      })
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/actual'
+        },
+        response: {
+          status: 200
+        }
+      })
+      .get('http://localhost:9393/mock/redirect')
+      .expectStatus(200);
+  });
+
   it('with Follow Redirects as false & default as true', async () => {
     pactum.request.setDefaultFollowRedirects(true);
     await pactum.spec()
@@ -618,6 +717,57 @@ describe('Interactions - Not Strict - Follow Redirects', () => {
       .expectStatus(301);
   });
 
+  it('with Follow Redirects as 0 & default as 1', async () => {
+    pactum.request.setDefaultFollowRedirects(1);
+    await pactum.spec()
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/redirect'
+        },
+        response: {
+          status: 301,
+          headers: {
+            'location': 'http://localhost:9393/mock/actual'
+          }
+        }
+      })
+      .get('http://localhost:9393/mock/redirect')
+      .withFollowRedirects(0)
+      .expectStatus(301);
+  });
+
+  it('with Follow Redirects as 1 & default as 0', async () => {
+    pactum.request.setDefaultFollowRedirects(0);
+    await pactum.spec()
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/redirect'
+        },
+        response: {
+          status: 301,
+          headers: {
+            'location': 'http://localhost:9393/mock/actual'
+          }
+        }
+      })
+      .useInteraction({
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/mock/actual'
+        },
+        response: {
+          status: 200
+        }
+      })
+      .get('http://localhost:9393/mock/redirect')
+      .withFollowRedirects(1)
+      .expectStatus(200);
+  });
 
   afterEach(() => {
     pactum.request.setDefaultFollowRedirects(false);


### PR DESCRIPTION
closes #372 

**Change Summary:**
* Allow withFollowRedirects and setDefaultFollowRedirects to support boolean and number parameters.
* Allow setting the followRedirects at 
  * request level `withFollowRedirects` 
  * global `setDefaultFollowRedirects` level.
* Default redirects should be `20` and should `>=0`
* Allow users to increase or decrease the redirect count

PR for documentation update - https://github.com/pactumjs/pactumjs.github.io/pull/55
