### PR TITLE
fix: Mock interaction type definitions

### DIFF
--- a/src/exports/mock.d.ts
+++ b/src/exports/mock.d.ts
@@ -29,6 +29,7 @@ export type InteractionResponse = (
 
 export interface InteractionResponseBase {
   headers?: object;
+  cookies?: object;
   body?: any;
   file?: string;
   fixedDelay?: number;

--- a/src/exports/mock.d.ts
+++ b/src/exports/mock.d.ts
@@ -22,10 +22,13 @@ export interface InteractionRequest extends CommonInteractionRequest {
   form?: object;
 }
 
-export interface InteractionResponse {
-  status: number;
+export type InteractionResponse = (
+  { onCall: OnCall; status?: number } // If onCall is present, status is optional
+  | (InteractionResponseBase & { status: number }) // If onCall is absent, status is required
+);
+
+export interface InteractionResponseBase {
   headers?: object;
-  cookies?: object;
   body?: any;
   file?: string;
   fixedDelay?: number;
@@ -39,7 +42,12 @@ export interface RandomDelay {
 }
 
 export interface OnCall {
-  [key: number]: InteractionResponse
+  [key: number]: Omit<InteractionResponseBase, 'onCall'> & { status: number };
+}
+
+export interface RandomDelay {
+  min: number;
+  max: number;
 }
 
 export interface InteractionExpectations {

--- a/src/exports/mock.d.ts
+++ b/src/exports/mock.d.ts
@@ -36,11 +36,6 @@ export interface InteractionResponseBase {
   onCall?: OnCall;
 }
 
-export interface RandomDelay {
-  min: number;
-  max: number;
-}
-
 export interface OnCall {
   [key: number]: Omit<InteractionResponseBase, 'onCall'> & { status: number };
 }

--- a/test/component/expects.spec.js
+++ b/test/component/expects.spec.js
@@ -134,7 +134,7 @@ describe('Expects', () => {
     } catch (error) {
       err = error;
     }
-    expect(err.message).equals('HTTP status 404 !== 200');
+    expect(err.message).to.satisfy(msg => msg.startsWith('HTTP status 404 !== 200'));
   });
 
   it('failed status code with custom message', async () => {
@@ -148,7 +148,7 @@ describe('Expects', () => {
     } catch (error) {
       err = error;
     }
-    expect(err.message).equals(`${customMessage}\n HTTP status 404 !== 200`);
+    expect(err.message).to.satisfy(msg => msg.startsWith((`${customMessage}\n HTTP status 404 !== 200`)));
   });
 
   it('header key not found', async () => {

--- a/test/component/non.crud.spec.js
+++ b/test/component/non.crud.spec.js
@@ -48,7 +48,7 @@ describe('Non CRUD Requests - Numbered Waits', () => {
     } catch (error) {
       err = error
     }
-    expect(err.message).equals('HTTP status 404 !== 200');
+    expect(err.message).to.satisfy(msg => msg.startsWith('HTTP status 404 !== 200'));
   });
 
   it('should fail when bg interactions are not exercised without any waits', async () => {
@@ -161,7 +161,7 @@ describe('Non CRUD Requests - Wait Handlers', () => {
     } catch (error) {
       err = error;
     }
-    expect(err.message).equals('HTTP status 404 !== 500');
+    expect(err.message).to.satisfy(msg => msg.startsWith('HTTP status 404 !== 500'));
   });
 
 });

--- a/test/component/response.spec.js
+++ b/test/component/response.spec.js
@@ -21,7 +21,7 @@ describe('Response', () => {
     } catch (error) {
       err = error;
     }
-    expect(err.message).equals('HTTP status 404 !== 200');
+    expect(err.message).to.satisfy(msg => msg.startsWith('HTTP status 404 !== 200'));
   });
 
   it('with default expected response status - override value', async () => {


### PR DESCRIPTION
closes #381

Includes fixes for test failures with node v20.18.1 changes (https://github.com/nodejs/node/pull/54759) 
Node v20.18.1 has changes to assert: https://nodejs.org/en/blog/release/v20.18.1