### PR TITLE
Bugfix: Ensure array-style 'set-cookie' headers are parsed correctly

### DIFF
--- a/src/models/expect.js
+++ b/src/models/expect.js
@@ -128,6 +128,9 @@ class Expect {
       if (!actualCookie) {
         this.fail(`'set-cookie' key not found in response headers`);
       }
+      if (Array.isArray(actualCookie) && actualCookie.length > 1) {
+        actualCookie = actualCookie.join('; ') + ';';
+      }
       actualCookie = lc.parse(actualCookie);
       const msg = jlv.validate(actualCookie, expectedCookie, { target: 'Cookie' });
       if (msg) this.fail(msg);


### PR DESCRIPTION
closes #287 

- When an `actualCookie` is an array with multiple elements, they are joined with `'; '` to make a single string before parsing.
  - It is OK without it, but adding `';'` after all `join()` operations are complete ensures that the state before parsing multiple cookies is the same as a single string cookie.

Example: 
If an array of cookies like `["one=1", "two=2"]` is set via `set-cookie` header, the `join()` operation will result in a string like `'one=1; two=2;'` which can be parsed correctly.