### PR TITLE
chore: replace lightcookie with cookie-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@exodus/schemasafe": "^1.3.0",
+        "cookie-lite": "^0.0.1",
         "deep-override": "^1.0.2",
         "form-data-lite": "^1.0.3",
         "json-query": "^2.2.2",
         "klona": "^2.0.6",
-        "lightcookie": "^1.0.25",
         "openapi-fuzzer-core": "^1.0.6",
         "pactum-matchers": "^1.1.7",
         "parse-graphql": "^1.0.0",
@@ -1062,11 +1062,21 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/cookie-lite": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/cookie-lite/-/cookie-lite-0.0.1.tgz",
+      "integrity": "sha512-jczNOBIPFsep1+HVBh/RDVU/sdIyTOfpP90jy+D8SwQ4jh8GOJJzXOY0Rs9mogg+gIWeKyREOGt/4xLHdIqtHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1785,11 +1795,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/lightcookie": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/lightcookie/-/lightcookie-1.0.25.tgz",
-      "integrity": "sha512-SrY/+eBPaKAMnsn7mCsoOMZzoQyCyHHHZlFCu2fjo28XxSyCLjlooKiTxyrXTg8NPaHp1YzWi0lcGG1gDi6KHw=="
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2327,10 +2332,11 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-      "dev": true
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -3783,10 +3789,15 @@
         }
       }
     },
+    "cookie-lite": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/cookie-lite/-/cookie-lite-0.0.1.tgz",
+      "integrity": "sha512-jczNOBIPFsep1+HVBh/RDVU/sdIyTOfpP90jy+D8SwQ4jh8GOJJzXOY0Rs9mogg+gIWeKyREOGt/4xLHdIqtHA=="
+    },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -4290,11 +4301,6 @@
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
       "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="
     },
-    "lightcookie": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/lightcookie/-/lightcookie-1.0.25.tgz",
-      "integrity": "sha512-SrY/+eBPaKAMnsn7mCsoOMZzoQyCyHHHZlFCu2fjo28XxSyCLjlooKiTxyrXTg8NPaHp1YzWi0lcGG1gDi6KHw=="
-    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4720,9 +4726,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true
     },
     "pathval": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "form-data-lite": "^1.0.3",
     "json-query": "^2.2.2",
     "klona": "^2.0.6",
-    "lightcookie": "^1.0.25",
+    "cookie-lite": "^0.0.1",
     "openapi-fuzzer-core": "^1.0.6",
     "pactum-matchers": "^1.1.7",
     "parse-graphql": "^1.0.0",

--- a/src/helpers/toss.helper.js
+++ b/src/helpers/toss.helper.js
@@ -1,4 +1,4 @@
-const lc = require('lightcookie');
+const cl = require('cookie-lite');
 const jqy = require('json-query');
 
 const config = require('../config');
@@ -30,7 +30,7 @@ function getPathValueFromRequestResponse(path, request, response) {
     if (!request.headers) {
       request.headers = {};
     }
-    const cookies = lc.parse(request.headers['cookie']);
+    const cookies = cl.parse(request.headers['cookie']);
     data = cookies;
   } else if (path.startsWith('req.body')) {
     path = path.replace('req.body', '');
@@ -43,7 +43,7 @@ function getPathValueFromRequestResponse(path, request, response) {
     if (!response.headers) {
       response.headers = {};
     }
-    const cookies = lc.parse(response.headers['set-cookie']);
+    const cookies = cl.parse(response.headers['set-cookie']);
     data = cookies;
   } else {
     path = path.replace('res.body', '');

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,6 +1,6 @@
 const { compare } = require('pactum-matchers').utils;
 const graphQL = require('./graphQL');
-const lc = require('lightcookie');
+const cl = require('cookie-lite');
 const { PactumRequestError } = require('../helpers/errors');
 
 const log = require('../plugins/logger');
@@ -69,7 +69,7 @@ const utils = {
       if (value !== undefined) {
         cookieObject[key] = value;
       } else if (value === undefined) {
-        cookieObject = lc.parse(key);
+        cookieObject = cl.parse(key);
       }
     } else {
       if (!helper.isValidObject(key)) {

--- a/src/models/Interaction.model.js
+++ b/src/models/Interaction.model.js
@@ -1,4 +1,4 @@
-const lc = require('lightcookie');
+const cl = require('cookie-lite');
 const { setMatchingRules, getValue } = require('pactum-matchers').utils;
 const processor = require('../helpers/dataProcessor');
 const helper = require('../helpers/helper');
@@ -121,7 +121,7 @@ class InteractionRequest {
       this.headers = getValue(request.headers);
     }
     if (request.cookies && typeof request.cookies === 'object') {
-      const cookie = lc.serialize(request.cookies);
+      const cookie = cl.serialize(request.cookies);
       if (!this.headers) {
         this.headers = {};
       }
@@ -170,7 +170,7 @@ class InteractionResponse {
     setMatchingRules(this.matchingRules, response.body, '$.body');
     this.body = getValue(response.body);
     if (response.cookies) {
-      const cookie = lc.serialize(response.cookies);
+      const cookie = cl.serialize(response.cookies);
       if (!this.headers) {
         this.headers = {};
       }

--- a/src/models/Spec.js
+++ b/src/models/Spec.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const lc = require('lightcookie');
+const cl = require('cookie-lite');
 const override = require('deep-override');
 const path = require('path');
 const Tosser = require('./Tosser');
@@ -244,7 +244,7 @@ class Spec {
     }
     let cookie;
     if (typeof key === 'object') {
-      cookie = lc.serialize(key);
+      cookie = cl.serialize(key);
     } else {
       if (value) {
         cookie = `${key}=${value}`;

--- a/src/models/expect.js
+++ b/src/models/expect.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const jqy = require('json-query');
-const lc = require('lightcookie');
+const cl = require('cookie-lite');
 
 const config = require('../config');
 const utils = require('../helpers/utils');
@@ -115,7 +115,7 @@ class Expect {
       if (!actualCookie) {
         this.fail(`'set-cookie' key not found in response headers`);
       }
-      actualCookie = lc.parse(actualCookie);
+      actualCookie = cl.parse(actualCookie);
       assert.deepStrictEqual(actualCookie, expectedCookie);
     }
   }
@@ -131,7 +131,7 @@ class Expect {
       if (Array.isArray(actualCookie) && actualCookie.length > 1) {
         actualCookie = actualCookie.join('; ') + ';';
       }
-      actualCookie = lc.parse(actualCookie);
+      actualCookie = cl.parse(actualCookie);
       const msg = jlv.validate(actualCookie, expectedCookie, { target: 'Cookie' });
       if (msg) this.fail(msg);
     }


### PR DESCRIPTION
**Summary**
- closes #396 
- Replaced [lightcookie](https://www.npmjs.com/package/lightcookie) with [cookie-lite](https://www.npmjs.com/package/cookie-lite) post `lightcookie` deprecation. Details [here](https://github.com/ethan7g/lightcookie/issues/3)
- `npm audit fix` for below
<img width="914" alt="image" src="https://github.com/user-attachments/assets/c961457a-90ed-4990-920a-619dbe664ae0" />

