### PR TITLE
fix: add optional encoding parameter to findFileRecursively for flexible return type

### DIFF
--- a/src/helpers/file.utils.js
+++ b/src/helpers/file.utils.js
@@ -30,14 +30,14 @@ function saveSnapshot(name, data) {
   fs.writeFileSync(`${snapshotDir}/${snapshotFile}`, JSON.stringify(data, null, 2));
 }
 
-function findFileRecursively(name, dir = config.data.dir) {
+function findFileRecursively(name, dir = config.data.dir, encoding = null) {
   if (fs.existsSync(name)) {
-    return fs.readFileSync(name);
+    return fs.readFileSync(name, encoding);
   }
   if (fs.existsSync(dir)) {
     const exist = fs.existsSync(`${dir}/${name}`);
     if (exist) {
-      return fs.readFileSync(`${dir}/${name}`);
+      return fs.readFileSync(`${dir}/${name}`, encoding);
     }
     // get folders in dir
     const files = fs.readdirSync(dir);
@@ -45,7 +45,7 @@ function findFileRecursively(name, dir = config.data.dir) {
       const dirPath = pt.resolve(dir, file);
       const stats = fs.statSync(dirPath);
       if (stats.isDirectory()) {
-        const result = findFileRecursively(name, dirPath);
+        const result = findFileRecursively(name, dirPath, encoding);
         if (result) {
           return result;
         }


### PR DESCRIPTION
This PR enhances the findFileRecursively utility function by introducing an optional encoding parameter. This allows callers to specify the desired return type when reading files:

-  If encoding is set (e.g., 'utf8'), the function returns the file content as a string.

-  If encoding is omitted or set to null, the function returns a Buffer (default Node.js behaviour).